### PR TITLE
Added transition animation between fragments

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -35,10 +35,12 @@ android {
 
 dependencies {
 
+    implementation 'com.github.bumptech.glide:glide:4.15.0'
+    annotationProcessor 'com.github.bumptech.glide:compiler:4.15.0'
     implementation 'androidx.core:core-ktx:1.9.0'
     implementation 'androidx.appcompat:appcompat:1.6.1'
     implementation 'com.google.android.material:material:1.8.0'
-    implementation 'androidx.recyclerview:recyclerview:1.2.1'
+    implementation 'androidx.recyclerview:recyclerview:1.3.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'

--- a/app/src/main/java/com/sandev/moviesearcher/MainActivity.kt
+++ b/app/src/main/java/com/sandev/moviesearcher/MainActivity.kt
@@ -20,7 +20,7 @@ import com.sandev.moviesearcher.movieListRecyclerView.data.Movie
 
 class MainActivity : AppCompatActivity() {
 
-    var poppedFragmentName: String? = null
+    var previousFragmentName: String? = null
 
     private var backPressedLastTime: Long = 0
     private var homeFragmentCommitId: Int = FRAGMENT_UNCOMMITTED
@@ -82,7 +82,7 @@ class MainActivity : AppCompatActivity() {
             setOnItemSelectedListener {
                 when (it.itemId) {
                     R.id.bottom_navigation_all_movies_button -> {
-                        poppedFragmentName = supportFragmentManager.fragments.last()::class.qualifiedName
+                        previousFragmentName = supportFragmentManager.fragments.last()::class.qualifiedName
                         supportFragmentManager.popBackStack(homeFragmentCommitId, 0)
                         true
                     }
@@ -92,6 +92,7 @@ class MainActivity : AppCompatActivity() {
                     }
                     R.id.bottom_navigation_favorites_button -> {
                         if (favoritesFragmentCommitId == FRAGMENT_UNCOMMITTED) {
+                            previousFragmentName = supportFragmentManager.fragments.last()::class.qualifiedName
                             favoritesFragmentCommitId = supportFragmentManager
                                 .beginTransaction()
                                 .replace(R.id.fragment, FavoritesFragment())
@@ -165,11 +166,11 @@ class MainActivity : AppCompatActivity() {
                 } else if (supportFragmentManager.fragments.last() is DetailsFragment) {
                     if (!(supportFragmentManager.fragments.last() as DetailsFragment)
                             .collapsingToolbarHasBeenExpanded()) {
-                        poppedFragmentName = supportFragmentManager.fragments.last()::class.qualifiedName
+                        previousFragmentName = supportFragmentManager.fragments.last()::class.qualifiedName
                         supportFragmentManager.popBackStack()
                     }
                 } else {
-                    poppedFragmentName = supportFragmentManager.fragments.last()::class.qualifiedName
+                    previousFragmentName = supportFragmentManager.fragments.last()::class.qualifiedName
                     supportFragmentManager.popBackStack()
                 }
             }

--- a/app/src/main/java/com/sandev/moviesearcher/MainActivity.kt
+++ b/app/src/main/java/com/sandev/moviesearcher/MainActivity.kt
@@ -3,15 +3,14 @@ package com.sandev.moviesearcher
 import android.content.res.Configuration
 import android.graphics.Outline
 import android.os.Bundle
-import android.view.*
+import android.view.View
+import android.view.ViewOutlineProvider
 import android.view.animation.DecelerateInterpolator
 import android.widget.ImageView
 import android.widget.Toast
 import androidx.activity.OnBackPressedCallback
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.*
-import androidx.transition.Slide
-import androidx.transition.TransitionManager
 import com.google.android.material.bottomnavigation.BottomNavigationView
 import com.sandev.moviesearcher.fragments.DetailsFragment
 import com.sandev.moviesearcher.fragments.FavoritesFragment
@@ -20,6 +19,8 @@ import com.sandev.moviesearcher.movieListRecyclerView.data.Movie
 
 
 class MainActivity : AppCompatActivity() {
+
+    var poppedFragmentName: String? = null
 
     private var backPressedLastTime: Long = 0
     private var homeFragmentCommitId: Int = FRAGMENT_UNCOMMITTED
@@ -81,6 +82,7 @@ class MainActivity : AppCompatActivity() {
             setOnItemSelectedListener {
                 when (it.itemId) {
                     R.id.bottom_navigation_all_movies_button -> {
+                        poppedFragmentName = supportFragmentManager.fragments.last()::class.qualifiedName
                         supportFragmentManager.popBackStack(homeFragmentCommitId, 0)
                         true
                     }
@@ -163,9 +165,11 @@ class MainActivity : AppCompatActivity() {
                 } else if (supportFragmentManager.fragments.last() is DetailsFragment) {
                     if (!(supportFragmentManager.fragments.last() as DetailsFragment)
                             .collapsingToolbarHasBeenExpanded()) {
+                        poppedFragmentName = supportFragmentManager.fragments.last()::class.qualifiedName
                         supportFragmentManager.popBackStack()
                     }
                 } else {
+                    poppedFragmentName = supportFragmentManager.fragments.last()::class.qualifiedName
                     supportFragmentManager.popBackStack()
                 }
             }

--- a/app/src/main/java/com/sandev/moviesearcher/MainActivity.kt
+++ b/app/src/main/java/com/sandev/moviesearcher/MainActivity.kt
@@ -3,13 +3,15 @@ package com.sandev.moviesearcher
 import android.content.res.Configuration
 import android.graphics.Outline
 import android.os.Bundle
-import android.view.View
-import android.view.ViewOutlineProvider
+import android.view.*
+import android.view.animation.DecelerateInterpolator
 import android.widget.ImageView
 import android.widget.Toast
 import androidx.activity.OnBackPressedCallback
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.*
+import androidx.transition.Slide
+import androidx.transition.TransitionManager
 import com.google.android.material.bottomnavigation.BottomNavigationView
 import com.sandev.moviesearcher.fragments.DetailsFragment
 import com.sandev.moviesearcher.fragments.FavoritesFragment
@@ -44,6 +46,16 @@ class MainActivity : AppCompatActivity() {
         menuButtonsInitial()
 
         if (supportFragmentManager.backStackEntryCount == 0) {
+            findViewById<BottomNavigationView>(R.id.navigation_bar).doOnLayout {
+                it.translationY = it.height.toFloat()
+                it.animate()
+                    .setDuration(resources.getInteger(
+                        R.integer.activity_main_animations_durations_first_appearance_navigation_bar).toLong())
+                    .translationY(0f)
+                    .setInterpolator(DecelerateInterpolator())
+                    .start()
+            }
+
             homeFragmentCommitId = supportFragmentManager
                 .beginTransaction()
                 .add(R.id.fragment, HomeFragment())

--- a/app/src/main/java/com/sandev/moviesearcher/fragments/DetailsFragment.kt
+++ b/app/src/main/java/com/sandev/moviesearcher/fragments/DetailsFragment.kt
@@ -13,6 +13,9 @@ import android.widget.TextView
 import androidx.core.os.bundleOf
 import androidx.core.view.*
 import androidx.fragment.app.Fragment
+import androidx.interpolator.view.animation.FastOutLinearInInterpolator
+import androidx.interpolator.view.animation.FastOutSlowInInterpolator
+import androidx.interpolator.view.animation.LinearOutSlowInInterpolator
 import androidx.transition.Fade
 import androidx.transition.Slide
 import androidx.transition.TransitionInflater
@@ -214,24 +217,35 @@ class DetailsFragment : Fragment() {
         val appBar: AppBarLayout = view.findViewById(R.id.app_bar)
         val movieTitle: TextView = view.findViewById(R.id.title)
         val movieDescription: TextView = view.findViewById(R.id.description)
+        val fabFavorite: FloatingActionButton = view.findViewById(R.id.fab_to_favorite)
+        val fabWatchLater: FloatingActionButton = view.findViewById(R.id.fab_to_watch_later)
+        val fabShare: FloatingActionButton = view.findViewById(R.id.fab_share)
+        val duration = resources.getInteger(R.integer.activity_main_animations_durations_poster_transition)
+            .toLong()
+
         enterTransition = TransitionSet().apply {
-            val appBarTransition = Slide(Gravity.TOP).apply {
-                mode = Slide.MODE_IN
-                duration = resources.getInteger(R.integer.activity_main_animations_durations_poster_transition)
-                        .toLong()
+            val appBarTransition = Fade().apply {
+                mode = Fade.MODE_IN
                 interpolator = DecelerateInterpolator()
                 addTarget(appBar)
             }
             val movieInformationTransition = Fade().apply {
                 mode = Fade.MODE_IN
-                duration = resources.getInteger(R.integer.activity_main_animations_durations_poster_transition)
-                        .toLong()
-                interpolator = AccelerateInterpolator()
+                interpolator = FastOutLinearInInterpolator()
                 addTarget(movieTitle)
                 addTarget(movieDescription)
             }
+            val fabTransition = Slide(Gravity.END).apply {
+                mode = Slide.MODE_IN
+                interpolator = LinearOutSlowInInterpolator()
+                addTarget(fabFavorite)
+                addTarget(fabWatchLater)
+                addTarget(fabShare)
+            }
+            this.duration = duration
             addTransition(appBarTransition)
             addTransition(movieInformationTransition)
+            addTransition(fabTransition)
         }
     }
 }

--- a/app/src/main/java/com/sandev/moviesearcher/fragments/DetailsFragment.kt
+++ b/app/src/main/java/com/sandev/moviesearcher/fragments/DetailsFragment.kt
@@ -20,6 +20,7 @@ import androidx.transition.Fade
 import androidx.transition.Slide
 import androidx.transition.TransitionInflater
 import androidx.transition.TransitionSet
+import com.bumptech.glide.Glide
 import com.google.android.material.appbar.AppBarLayout
 import com.google.android.material.appbar.CollapsingToolbarLayout
 import com.google.android.material.appbar.MaterialToolbar
@@ -123,7 +124,7 @@ class DetailsFragment : Fragment() {
         movie = arguments?.getParcelable(MainActivity.MOVIE_DATA_KEY)!!
 
         view.findViewById<ImageView>(R.id.collapsing_toolbar_image).apply {
-            setImageResource(movie.poster)
+            Glide.with(this@DetailsFragment).load(movie.poster).centerCrop().into(this)
             transitionName = arguments?.getString(MainActivity.POSTER_TRANSITION_KEY)
         }
         view.findViewById<TextView>(R.id.title).text = movie.title

--- a/app/src/main/java/com/sandev/moviesearcher/fragments/DetailsFragment.kt
+++ b/app/src/main/java/com/sandev/moviesearcher/fragments/DetailsFragment.kt
@@ -3,18 +3,20 @@ package com.sandev.moviesearcher.fragments
 import android.content.Intent
 import android.graphics.Outline
 import android.os.Bundle
-import android.view.LayoutInflater
-import android.view.View
+import android.view.*
 import android.view.View.GONE
 import android.view.View.VISIBLE
-import android.view.ViewGroup
-import android.view.ViewOutlineProvider
+import android.view.animation.AccelerateInterpolator
+import android.view.animation.DecelerateInterpolator
 import android.widget.ImageView
 import android.widget.TextView
 import androidx.core.os.bundleOf
 import androidx.core.view.*
 import androidx.fragment.app.Fragment
+import androidx.transition.Fade
+import androidx.transition.Slide
 import androidx.transition.TransitionInflater
+import androidx.transition.TransitionSet
 import com.google.android.material.appbar.AppBarLayout
 import com.google.android.material.appbar.CollapsingToolbarLayout
 import com.google.android.material.appbar.MaterialToolbar
@@ -52,7 +54,7 @@ class DetailsFragment : Fragment() {
         setToolbarBackButton(view)
         setFloatButtonOnClick(view)
 
-        sharedElementEnterTransition = TransitionInflater.from(context).inflateTransition(R.transition.poster_transition)
+        setTransitionAnimation(view)
 
         activity?.findViewById<BottomNavigationView>(R.id.navigation_bar)?.run {
             animate()  // Убрать нижний navigation view
@@ -203,6 +205,33 @@ class DetailsFragment : Fragment() {
         } else if (isFavoriteMovie && !toFavoriteButton.isSelected) {
             isFavoriteMovie = false
             favoriteMovies.remove(movie)
+        }
+    }
+
+    private fun setTransitionAnimation(view: View) {
+        sharedElementEnterTransition = TransitionInflater.from(context).inflateTransition(R.transition.poster_transition)
+
+        val appBar: AppBarLayout = view.findViewById(R.id.app_bar)
+        val movieTitle: TextView = view.findViewById(R.id.title)
+        val movieDescription: TextView = view.findViewById(R.id.description)
+        enterTransition = TransitionSet().apply {
+            val appBarTransition = Slide(Gravity.TOP).apply {
+                mode = Slide.MODE_IN
+                duration = resources.getInteger(R.integer.activity_main_animations_durations_poster_transition)
+                        .toLong()
+                interpolator = DecelerateInterpolator()
+                addTarget(appBar)
+            }
+            val movieInformationTransition = Fade().apply {
+                mode = Fade.MODE_IN
+                duration = resources.getInteger(R.integer.activity_main_animations_durations_poster_transition)
+                        .toLong()
+                interpolator = AccelerateInterpolator()
+                addTarget(movieTitle)
+                addTarget(movieDescription)
+            }
+            addTransition(appBarTransition)
+            addTransition(movieInformationTransition)
         }
     }
 }

--- a/app/src/main/java/com/sandev/moviesearcher/fragments/FavoritesFragment.kt
+++ b/app/src/main/java/com/sandev/moviesearcher/fragments/FavoritesFragment.kt
@@ -91,7 +91,6 @@ class FavoritesFragment : MoviesListFragment() {
         moviesListRecycler.isNestedScrollingEnabled = true
         moviesListRecycler.adapter = favoriteMoviesRecyclerAdapter
         favoriteMoviesRecyclerManager = moviesListRecycler.layoutManager!!
-        moviesListRecycler.layoutAnimation = AnimationUtils.loadLayoutAnimation(requireContext(), R.anim.posters_appearance)
         moviesListRecycler.itemAnimator = MovieItemAnimator()
 
         moviesListRecycler.postDelayed(  // Запускать удаление только после отрисовки анимации recycler
@@ -115,28 +114,34 @@ class FavoritesFragment : MoviesListFragment() {
 
         sharedElementReturnTransition = TransitionInflater.from(context).inflateTransition(R.transition.poster_transition)
         postponeEnterTransition()  // не запускать анимацию возвращения постера в список пока не просчитается recycler
+
+        val recycler: RecyclerView = rootView.findViewById(R.id.movies_list_recycler)
+        if ((activity as MainActivity).previousFragmentName == DetailsFragment::class.qualifiedName) {
+            recycler.layoutAnimation = AnimationUtils.loadLayoutAnimation(requireContext(), R.anim.posters_appearance)
+        }
     }
 
-    fun setDefaultTransitionAnimation(view: View) {
+    override fun setDefaultTransitionAnimation(view: View) {
         val searchBar: SearchBar = view.findViewById(R.id.search_bar)
         val recycler: RecyclerView = view.findViewById(R.id.movies_list_recycler)
         val duration = resources.getInteger(R.integer.general_animations_durations_fragment_transition).toLong()
 
-        val appBarTransition = Fade().apply {
-            this.duration = duration
-            interpolator = DecelerateInterpolator()
-            addTarget(searchBar)
-        }
         val recyclerTransition = Slide(Gravity.END).apply {
             this.duration = duration
             interpolator = LinearInterpolator()
             addTarget(recycler)
         }
-        enterTransition = TransitionSet()
-            .addTransition(appBarTransition)
-            .addTransition(recyclerTransition)
-        returnTransition = TransitionSet()
-            .addTransition(appBarTransition)
-            .addTransition(recyclerTransition)
+        val transitionSet = TransitionSet().addTransition(recyclerTransition)
+
+        if (!isAppBarLifted) {
+            val appBarTransition = Fade().apply {
+                this.duration = duration
+                interpolator = DecelerateInterpolator()
+                addTarget(searchBar)
+            }
+            transitionSet.addTransition(appBarTransition)
+        }
+        enterTransition = transitionSet
+        returnTransition = transitionSet
     }
 }

--- a/app/src/main/java/com/sandev/moviesearcher/fragments/FavoritesFragment.kt
+++ b/app/src/main/java/com/sandev/moviesearcher/fragments/FavoritesFragment.kt
@@ -1,15 +1,22 @@
 package com.sandev.moviesearcher.fragments
 
 import android.os.Bundle
+import android.view.Gravity
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.view.animation.AnimationUtils
+import android.view.animation.DecelerateInterpolator
+import android.view.animation.LinearInterpolator
 import android.widget.ImageView
 import androidx.core.view.doOnPreDraw
 import androidx.core.view.postDelayed
 import androidx.recyclerview.widget.RecyclerView
+import androidx.transition.Fade
+import androidx.transition.Slide
 import androidx.transition.TransitionInflater
+import androidx.transition.TransitionSet
+import com.google.android.material.search.SearchBar
 import com.sandev.moviesearcher.MainActivity
 import com.sandev.moviesearcher.R
 import com.sandev.moviesearcher.movieListRecyclerView.adapter.MoviesRecyclerAdapter
@@ -47,9 +54,7 @@ class FavoritesFragment : MoviesListFragment() {
     ): View? {
         val rootView = layoutInflater.inflate(R.layout.fragment_favorites, container, false)
 
-        sharedElementReturnTransition = TransitionInflater.from(context).inflateTransition(R.transition.poster_transition)
-        returnTransition = TransitionInflater.from(context).inflateTransition(android.R.transition.no_transition)
-        postponeEnterTransition()  // не запускать анимацию возвращения постера в список пока не просчитается recycler
+        setAnimationTransition(rootView)
 
         return rootView
     }
@@ -103,5 +108,35 @@ class FavoritesFragment : MoviesListFragment() {
             }
         }
         moviesListRecycler.doOnPreDraw { startPostponedEnterTransition() }
+    }
+
+    private fun setAnimationTransition(rootView: View) {
+        setDefaultTransitionAnimation(rootView)
+
+        sharedElementReturnTransition = TransitionInflater.from(context).inflateTransition(R.transition.poster_transition)
+        postponeEnterTransition()  // не запускать анимацию возвращения постера в список пока не просчитается recycler
+    }
+
+    fun setDefaultTransitionAnimation(view: View) {
+        val searchBar: SearchBar = view.findViewById(R.id.search_bar)
+        val recycler: RecyclerView = view.findViewById(R.id.movies_list_recycler)
+        val duration = resources.getInteger(R.integer.general_animations_durations_fragment_transition).toLong()
+
+        val appBarTransition = Fade().apply {
+            this.duration = duration
+            interpolator = DecelerateInterpolator()
+            addTarget(searchBar)
+        }
+        val recyclerTransition = Slide(Gravity.END).apply {
+            this.duration = duration
+            interpolator = LinearInterpolator()
+            addTarget(recycler)
+        }
+        enterTransition = TransitionSet()
+            .addTransition(appBarTransition)
+            .addTransition(recyclerTransition)
+        returnTransition = TransitionSet()
+            .addTransition(appBarTransition)
+            .addTransition(recyclerTransition)
     }
 }

--- a/app/src/main/java/com/sandev/moviesearcher/fragments/HomeFragment.kt
+++ b/app/src/main/java/com/sandev/moviesearcher/fragments/HomeFragment.kt
@@ -107,7 +107,7 @@ class HomeFragment : MoviesListFragment() {
         }
 
         val recycler: RecyclerView = rootView.findViewById(R.id.movies_list_recycler)
-        if ((activity as MainActivity).poppedFragmentName == DetailsFragment::class.qualifiedName) {
+        if ((activity as MainActivity).previousFragmentName == DetailsFragment::class.qualifiedName) {
             // Не включать transition анимации после выхода из окна деталей
             rootView.postDelayed(resources.getInteger(R.integer.activity_main_animations_durations_poster_transition).toLong()) {
                 setDefaultTransitionAnimation(rootView)
@@ -120,28 +120,28 @@ class HomeFragment : MoviesListFragment() {
         }
     }
 
-    private fun setDefaultTransitionAnimation(view: View) {
+    override fun setDefaultTransitionAnimation(view: View) {
         val searchBar: SearchBar = view.findViewById(R.id.search_bar)
         val recycler: RecyclerView = view.findViewById(R.id.movies_list_recycler)
         val duration = resources.getInteger(R.integer.general_animations_durations_fragment_transition).toLong()
 
-        val appBarTransition = Fade().apply {
-            this.duration = duration
-            interpolator = AccelerateInterpolator()
-            addTarget(searchBar)
-        }
         val recyclerTransition = Slide(Gravity.START).apply {
             this.duration = duration
             interpolator = LinearInterpolator()
             addTarget(recycler)
         }
+        val transitionSet = TransitionSet().addTransition(recyclerTransition)
 
-        exitTransition = TransitionSet()
-            .addTransition(appBarTransition)
-            .addTransition(recyclerTransition)
-        reenterTransition = TransitionSet()
-            .addTransition(appBarTransition)
-            .addTransition(recyclerTransition)
+        if (!isAppBarLifted) {
+            val appBarTransition = Fade().apply {
+                this.duration = duration
+                interpolator = AccelerateInterpolator()
+                addTarget(searchBar)
+            }
+            transitionSet.addTransition(appBarTransition)
+        }
+        exitTransition = transitionSet
+        reenterTransition = transitionSet
     }
 
     private fun resetDefaultTransitionAnimation() {

--- a/app/src/main/java/com/sandev/moviesearcher/fragments/HomeFragment.kt
+++ b/app/src/main/java/com/sandev/moviesearcher/fragments/HomeFragment.kt
@@ -27,9 +27,10 @@ class HomeFragment : MoviesListFragment() {
     private var moviesRecyclerManager: RecyclerView.LayoutManager? = null
     private var moviesRecyclerAdapter: MoviesRecyclerAdapter? = null
     override var lastSearch: CharSequence? = null
-    private var isFragmentClassCreated = false
 
     companion object {
+        private var isFragmentClassOnceCreated = false
+        
         private const val MOVIES_RECYCLER_VIEW_STATE = "MoviesRecylerViewState"
     }
 
@@ -85,7 +86,7 @@ class HomeFragment : MoviesListFragment() {
         postponeEnterTransition()  // не запускать анимацию возвращения постера в список пока не просчитается recycler
 
         val scene = Scene.getSceneForLayout(rootView as ViewGroup, R.layout.merge_fragment_home_content, requireContext())
-        if (!isFragmentClassCreated) {  // запускать анимацию первого появления только при создании класса
+        if (!isFragmentClassOnceCreated) {  // запускать анимацию появления только при первой загрузке класса фрагмента
             val appBarSlideTransition = Slide(Gravity.TOP)
                 .setDuration(resources.getInteger(
                     R.integer.activity_main_animations_durations_first_appearance_app_bar).toLong())
@@ -101,7 +102,7 @@ class HomeFragment : MoviesListFragment() {
                 addTransition(moviesRecyclerTransition)
             }
             TransitionManager.go(scene, appearingTransition)
-            isFragmentClassCreated = true
+            isFragmentClassOnceCreated = true
         } else {
             scene.enter()
         }

--- a/app/src/main/java/com/sandev/moviesearcher/fragments/HomeFragment.kt
+++ b/app/src/main/java/com/sandev/moviesearcher/fragments/HomeFragment.kt
@@ -5,12 +5,16 @@ import android.view.Gravity
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.animation.AccelerateInterpolator
 import android.view.animation.AnimationUtils
 import android.view.animation.DecelerateInterpolator
+import android.view.animation.LinearInterpolator
 import android.widget.ImageView
 import androidx.core.view.doOnPreDraw
+import androidx.core.view.postDelayed
 import androidx.recyclerview.widget.RecyclerView
 import androidx.transition.*
+import com.google.android.material.search.SearchBar
 import com.sandev.moviesearcher.MainActivity
 import com.sandev.moviesearcher.R
 import com.sandev.moviesearcher.movieListRecyclerView.adapter.MoviesRecyclerAdapter
@@ -35,30 +39,7 @@ class HomeFragment : MoviesListFragment() {
     ): View {
         val rootView = layoutInflater.inflate(R.layout.fragment_home, container, false)
 
-        sharedElementReturnTransition = TransitionInflater.from(context).inflateTransition(R.transition.poster_transition)
-        postponeEnterTransition()  // не запускать анимацию возвращения постера в список пока не просчитается recycler
-
-        val scene = Scene.getSceneForLayout(rootView as ViewGroup, R.layout.merge_fragment_home_content, requireContext())
-        if (!isFragmentClassCreated) {  // запускать анимацию первого появления только при создании класса
-            val appBarSlideTransition = Slide(Gravity.TOP)
-                .setDuration(resources.getInteger(
-                    R.integer.activity_main_animations_durations_first_appearance_app_bar).toLong())
-                .setInterpolator(DecelerateInterpolator())
-                .addTarget(R.id.app_bar)
-            val moviesRecyclerTransition = Slide(Gravity.BOTTOM)
-                .setDuration(resources.getInteger(
-                    R.integer.activity_main_animations_durations_first_appearance_recycler).toLong())
-                .setInterpolator(DecelerateInterpolator())
-                .addTarget(R.id.movies_list_recycler)
-            val appearingTransition = TransitionSet().apply {
-                addTransition(appBarSlideTransition)
-                addTransition(moviesRecyclerTransition)
-            }
-            TransitionManager.go(scene, appearingTransition)
-            isFragmentClassCreated = true
-        } else {
-            scene.enter()
-        }
+        setTransitionAnimation(rootView)
 
         return rootView
     }
@@ -85,6 +66,7 @@ class HomeFragment : MoviesListFragment() {
         }
         moviesRecyclerAdapter!!.setPosterOnClickListener(object : MoviesRecyclerAdapter.OnClickListener {
             override fun onClick(movie: Movie, posterView: ImageView) {
+                resetDefaultTransitionAnimation()
                 (activity as MainActivity).startDetailsFragment(movie, posterView)
             }
         })
@@ -95,7 +77,75 @@ class HomeFragment : MoviesListFragment() {
         moviesListRecycler.adapter = moviesRecyclerAdapter
         moviesRecyclerManager = moviesListRecycler.layoutManager!!
 
-        moviesListRecycler.layoutAnimation = AnimationUtils.loadLayoutAnimation(requireContext(), R.anim.posters_appearance)
         moviesListRecycler.doOnPreDraw { startPostponedEnterTransition() }
+    }
+
+    private fun setTransitionAnimation(rootView: View) {
+        sharedElementReturnTransition = TransitionInflater.from(context).inflateTransition(R.transition.poster_transition)
+        postponeEnterTransition()  // не запускать анимацию возвращения постера в список пока не просчитается recycler
+
+        val scene = Scene.getSceneForLayout(rootView as ViewGroup, R.layout.merge_fragment_home_content, requireContext())
+        if (!isFragmentClassCreated) {  // запускать анимацию первого появления только при создании класса
+            val appBarSlideTransition = Slide(Gravity.TOP)
+                .setDuration(resources.getInteger(
+                    R.integer.activity_main_animations_durations_first_appearance_app_bar).toLong())
+                .setInterpolator(DecelerateInterpolator())
+                .addTarget(R.id.app_bar)
+            val moviesRecyclerTransition = Slide(Gravity.BOTTOM)
+                .setDuration(resources.getInteger(
+                    R.integer.activity_main_animations_durations_first_appearance_recycler).toLong())
+                .setInterpolator(DecelerateInterpolator())
+                .addTarget(R.id.movies_list_recycler)
+            val appearingTransition = TransitionSet().apply {
+                addTransition(appBarSlideTransition)
+                addTransition(moviesRecyclerTransition)
+            }
+            TransitionManager.go(scene, appearingTransition)
+            isFragmentClassCreated = true
+        } else {
+            scene.enter()
+        }
+
+        val recycler: RecyclerView = rootView.findViewById(R.id.movies_list_recycler)
+        if ((activity as MainActivity).poppedFragmentName == DetailsFragment::class.qualifiedName) {
+            // Не включать transition анимации после выхода из окна деталей
+            rootView.postDelayed(resources.getInteger(R.integer.activity_main_animations_durations_poster_transition).toLong()) {
+                setDefaultTransitionAnimation(rootView)
+            }
+            // LayoutAnimation для recycler включается только при возвращении с экрана деталей
+            recycler.layoutAnimation = AnimationUtils.loadLayoutAnimation(requireContext(), R.anim.posters_appearance)
+            resetDefaultTransitionAnimation()
+        } else {
+            setDefaultTransitionAnimation(rootView)
+        }
+    }
+
+    private fun setDefaultTransitionAnimation(view: View) {
+        val searchBar: SearchBar = view.findViewById(R.id.search_bar)
+        val recycler: RecyclerView = view.findViewById(R.id.movies_list_recycler)
+        val duration = resources.getInteger(R.integer.general_animations_durations_fragment_transition).toLong()
+
+        val appBarTransition = Fade().apply {
+            this.duration = duration
+            interpolator = AccelerateInterpolator()
+            addTarget(searchBar)
+        }
+        val recyclerTransition = Slide(Gravity.START).apply {
+            this.duration = duration
+            interpolator = LinearInterpolator()
+            addTarget(recycler)
+        }
+
+        exitTransition = TransitionSet()
+            .addTransition(appBarTransition)
+            .addTransition(recyclerTransition)
+        reenterTransition = TransitionSet()
+            .addTransition(appBarTransition)
+            .addTransition(recyclerTransition)
+    }
+
+    private fun resetDefaultTransitionAnimation() {
+        exitTransition = null
+        reenterTransition = null
     }
 }

--- a/app/src/main/java/com/sandev/moviesearcher/fragments/HomeFragment.kt
+++ b/app/src/main/java/com/sandev/moviesearcher/fragments/HomeFragment.kt
@@ -1,14 +1,16 @@
 package com.sandev.moviesearcher.fragments
 
 import android.os.Bundle
+import android.view.Gravity
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.view.animation.AnimationUtils
+import android.view.animation.DecelerateInterpolator
 import android.widget.ImageView
 import androidx.core.view.doOnPreDraw
 import androidx.recyclerview.widget.RecyclerView
-import androidx.transition.TransitionInflater
+import androidx.transition.*
 import com.sandev.moviesearcher.MainActivity
 import com.sandev.moviesearcher.R
 import com.sandev.moviesearcher.movieListRecyclerView.adapter.MoviesRecyclerAdapter
@@ -21,6 +23,7 @@ class HomeFragment : MoviesListFragment() {
     private var moviesRecyclerManager: RecyclerView.LayoutManager? = null
     private var moviesRecyclerAdapter: MoviesRecyclerAdapter? = null
     override var lastSearch: CharSequence? = null
+    private var isFragmentClassCreated = false
 
     companion object {
         private const val MOVIES_RECYCLER_VIEW_STATE = "MoviesRecylerViewState"
@@ -29,11 +32,33 @@ class HomeFragment : MoviesListFragment() {
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
-    ): View? {
+    ): View {
         val rootView = layoutInflater.inflate(R.layout.fragment_home, container, false)
 
         sharedElementReturnTransition = TransitionInflater.from(context).inflateTransition(R.transition.poster_transition)
         postponeEnterTransition()  // не запускать анимацию возвращения постера в список пока не просчитается recycler
+
+        val scene = Scene.getSceneForLayout(rootView as ViewGroup, R.layout.merge_fragment_home_content, requireContext())
+        if (!isFragmentClassCreated) {  // запускать анимацию первого появления только при создании класса
+            val appBarSlideTransition = Slide(Gravity.TOP)
+                .setDuration(resources.getInteger(
+                    R.integer.activity_main_animations_durations_first_appearance_app_bar).toLong())
+                .setInterpolator(DecelerateInterpolator())
+                .addTarget(R.id.app_bar)
+            val moviesRecyclerTransition = Slide(Gravity.BOTTOM)
+                .setDuration(resources.getInteger(
+                    R.integer.activity_main_animations_durations_first_appearance_recycler).toLong())
+                .setInterpolator(DecelerateInterpolator())
+                .addTarget(R.id.movies_list_recycler)
+            val appearingTransition = TransitionSet().apply {
+                addTransition(appBarSlideTransition)
+                addTransition(moviesRecyclerTransition)
+            }
+            TransitionManager.go(scene, appearingTransition)
+            isFragmentClassCreated = true
+        } else {
+            scene.enter()
+        }
 
         return rootView
     }

--- a/app/src/main/java/com/sandev/moviesearcher/fragments/MoviesListFragment.kt
+++ b/app/src/main/java/com/sandev/moviesearcher/fragments/MoviesListFragment.kt
@@ -143,7 +143,11 @@ abstract class MoviesListFragment : Fragment() {
             foreground = ColorDrawable(context.getColor(R.color.md_theme_secondaryContainer))
             foreground.alpha = 0
 
-            setExpanded(!isAppBarLifted, false)
+            if (resources.configuration.orientation == Configuration.ORIENTATION_LANDSCAPE) {
+                setExpanded(true, false)
+            } else {
+                setExpanded(!isAppBarLifted, false)
+            }
 
             val recycler = rootView.findViewById<RecyclerView>(R.id.movies_list_recycler)
             val searchView: SearchView = rootView.findViewById(R.id.search_view)

--- a/app/src/main/java/com/sandev/moviesearcher/movieListRecyclerView/viewHolder/MovieViewHolder.kt
+++ b/app/src/main/java/com/sandev/moviesearcher/movieListRecyclerView/viewHolder/MovieViewHolder.kt
@@ -4,17 +4,18 @@ import android.view.View
 import android.widget.ImageView
 import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
+import com.bumptech.glide.Glide
 import com.sandev.moviesearcher.R
 import com.sandev.moviesearcher.movieListRecyclerView.data.Movie
 
 
-class MovieViewHolder(view: View) : RecyclerView.ViewHolder(view) {
+class MovieViewHolder(private val view: View) : RecyclerView.ViewHolder(view) {
     val poster: ImageView = view.findViewById(R.id.movie_card_poster)
     private val title: TextView = view.findViewById(R.id.movie_card_movie_title)
     private val description: TextView = view.findViewById(R.id.movie_card_movie_description)
 
     fun onBind(movieData: Movie, position: Int) {
-        poster.setImageResource(movieData.poster)
+        Glide.with(view).load(movieData.poster).centerCrop().into(poster)
         poster.transitionName = poster.resources.getString(R.string.movie_view_holder_transition_name,
             position)
         title.text = movieData.title

--- a/app/src/main/res/layout-land/fragment_home.xml
+++ b/app/src/main/res/layout-land/fragment_home.xml
@@ -1,55 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.coordinatorlayout.widget.CoordinatorLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".fragments.HomeFragment">
-
-    <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/movies_list_recycler"
-        android:layout_width="match_parent"
-        android:layout_height="@dimen/activity_main.movies_recycler.movie_card.height"
-        android:layout_marginHorizontal="@dimen/activity_main.movies_recycler.margin_horizontal"
-        android:layout_marginVertical="@dimen/activity_main.movies_recycler.margin_vertical"
-        android:background="?attr/colorSecondaryContainer"
-        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
-        app:layout_behavior="@string/appbar_scrolling_view_behavior"
-        android:orientation="horizontal"
-        android:layout_below="@id/app_bar"
-        tools:listitem="@layout/movie_card" />
-
-    <com.google.android.material.appbar.AppBarLayout
-        android:id="@+id/app_bar"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:background="?attr/colorPrimaryContainer"
-        app:layout_behavior=".behaviors.UnshiftedAppBar">
-
-        <com.google.android.material.search.SearchBar
-            android:id="@+id/search_bar"
-            android:layout_width="match_parent"
-            android:layout_height="@dimen/activity_main.search_bar.height"
-            android:layout_margin="@dimen/activity_main.search_bar.margin"
-            android:theme="@style/Theme.MovieSearcher.Search"
-            style="@style/Widget.Material3.SearchBar.Outlined"
-            app:navigationIcon="@drawable/round_menu"
-            app:menu="@menu/top_app_bar_menu"
-            android:hint="@string/activity_main.top_app_bar.search_bar.hint"
-            app:defaultMarginsEnabled="false"
-            app:layout_scrollFlags="enterAlways|scroll|snap|snapMargins"
-            app:layout_scrollEffect="none" />
-    </com.google.android.material.appbar.AppBarLayout>
-
-    <com.google.android.material.search.SearchView
-        android:id="@+id/search_view"
-        android:layout_width="match_parent"
-        android:layout_height="@dimen/activity_main.search_view.height"
-        android:theme="@style/Theme.MovieSearcher.Search"
-        app:layout_anchor="@id/search_bar"
-        app:layout_anchorGravity="top"
-        android:hint="@string/activity_main.top_app_bar.search_bar.hint"
-        app:useDrawerArrowDrawable="true"
-        app:autoShowKeyboard="false" />
-</androidx.coordinatorlayout.widget.CoordinatorLayout>
+    tools:context=".fragments.HomeFragment" />

--- a/app/src/main/res/layout-land/merge_fragment_home_content.xml
+++ b/app/src/main/res/layout-land/merge_fragment_home_content.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".fragments.HomeFragment">
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/movies_list_recycler"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/activity_main.movies_recycler.movie_card.height"
+        android:layout_marginHorizontal="@dimen/activity_main.movies_recycler.margin_horizontal"
+        android:layout_marginVertical="@dimen/activity_main.movies_recycler.margin_vertical"
+        android:background="?attr/colorSecondaryContainer"
+        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior"
+        android:orientation="horizontal"
+        android:layout_below="@id/app_bar"
+        tools:listitem="@layout/movie_card" />
+
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/app_bar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="?attr/colorPrimaryContainer"
+        app:layout_behavior=".behaviors.UnshiftedAppBar">
+
+        <com.google.android.material.search.SearchBar
+            android:id="@+id/search_bar"
+            android:layout_width="match_parent"
+            android:layout_height="@dimen/activity_main.search_bar.height"
+            android:layout_margin="@dimen/activity_main.search_bar.margin"
+            android:theme="@style/Theme.MovieSearcher.Search"
+            style="@style/Widget.Material3.SearchBar.Outlined"
+            app:navigationIcon="@drawable/round_menu"
+            app:menu="@menu/top_app_bar_menu"
+            android:hint="@string/activity_main.top_app_bar.search_bar.hint"
+            app:defaultMarginsEnabled="false"
+            app:layout_scrollFlags="enterAlways|scroll|snap|snapMargins"
+            app:layout_scrollEffect="none" />
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <com.google.android.material.search.SearchView
+        android:id="@+id/search_view"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/activity_main.search_view.height"
+        android:theme="@style/Theme.MovieSearcher.Search"
+        app:layout_anchor="@id/search_bar"
+        app:layout_anchorGravity="top"
+        android:hint="@string/activity_main.top_app_bar.search_bar.hint"
+        app:useDrawerArrowDrawable="true"
+        app:autoShowKeyboard="false" />
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -3,6 +3,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/root_view"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context=".MainActivity">

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -1,52 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.coordinatorlayout.widget.CoordinatorLayout
+<androidx.constraintlayout.widget.ConstraintLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".fragments.HomeFragment">
-
-    <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/movies_list_recycler"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_marginHorizontal="@dimen/activity_main.movies_recycler.margin_horizontal"
-        android:layout_marginVertical="@dimen/activity_main.movies_recycler.margin_vertical"
-        android:background="?attr/colorSecondaryContainer"
-        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
-        app:layout_behavior="@string/appbar_scrolling_view_behavior"
-        tools:listitem="@layout/movie_card" />
-
-    <com.google.android.material.appbar.AppBarLayout
-        android:id="@+id/app_bar"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:background="?attr/colorPrimaryContainer">
-
-        <com.google.android.material.search.SearchBar
-            android:id="@+id/search_bar"
-            android:layout_width="match_parent"
-            android:layout_height="@dimen/activity_main.search_bar.height"
-            android:layout_margin="@dimen/activity_main.search_bar.margin"
-            android:theme="@style/Theme.MovieSearcher.Search"
-            style="@style/Widget.Material3.SearchBar.Outlined"
-            app:navigationIcon="@drawable/round_menu"
-            app:menu="@menu/top_app_bar_menu"
-            android:hint="@string/activity_main.top_app_bar.search_bar.hint"
-            app:defaultMarginsEnabled="false"
-            app:layout_scrollFlags="enterAlways|scroll|snap|snapMargins"
-            app:layout_scrollEffect="none" />
-    </com.google.android.material.appbar.AppBarLayout>
-
-    <com.google.android.material.search.SearchView
-        android:id="@+id/search_view"
-        android:layout_width="match_parent"
-        android:layout_height="@dimen/activity_main.search_view.height"
-        android:theme="@style/Theme.MovieSearcher.Search"
-        app:layout_anchor="@id/search_bar"
-        app:layout_anchorGravity="top"
-        android:hint="@string/activity_main.top_app_bar.search_bar.hint"
-        app:useDrawerArrowDrawable="true"
-        app:autoShowKeyboard="false" />
-</androidx.coordinatorlayout.widget.CoordinatorLayout>
+    tools:context=".fragments.HomeFragment" />

--- a/app/src/main/res/layout/merge_fragment_home_content.xml
+++ b/app/src/main/res/layout/merge_fragment_home_content.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".fragments.HomeFragment">
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/movies_list_recycler"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_marginHorizontal="@dimen/activity_main.movies_recycler.margin_horizontal"
+        android:layout_marginVertical="@dimen/activity_main.movies_recycler.margin_vertical"
+        android:background="?attr/colorSecondaryContainer"
+        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior"
+        tools:listitem="@layout/movie_card" />
+
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/app_bar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="?attr/colorPrimaryContainer">
+
+        <com.google.android.material.search.SearchBar
+            android:id="@+id/search_bar"
+            android:layout_width="match_parent"
+            android:layout_height="@dimen/activity_main.search_bar.height"
+            android:layout_margin="@dimen/activity_main.search_bar.margin"
+            android:theme="@style/Theme.MovieSearcher.Search"
+            style="@style/Widget.Material3.SearchBar.Outlined"
+            app:navigationIcon="@drawable/round_menu"
+            app:menu="@menu/top_app_bar_menu"
+            android:hint="@string/activity_main.top_app_bar.search_bar.hint"
+            app:defaultMarginsEnabled="false"
+            app:layout_scrollFlags="enterAlways|scroll|snap|snapMargins"
+            app:layout_scrollEffect="none" />
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <com.google.android.material.search.SearchView
+        android:id="@+id/search_view"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/activity_main.search_view.height"
+        android:theme="@style/Theme.MovieSearcher.Search"
+        app:layout_anchor="@id/search_bar"
+        app:layout_anchorGravity="top"
+        android:hint="@string/activity_main.top_app_bar.search_bar.hint"
+        app:useDrawerArrowDrawable="true"
+        app:autoShowKeyboard="false" />
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/transition/poster_transition.xml
+++ b/app/src/main/res/transition/poster_transition.xml
@@ -6,5 +6,4 @@
 
     <changeTransform/>
     <changeBounds/>
-    <changeImageTransform/>
 </transitionSet>

--- a/app/src/main/res/values/integers.xml
+++ b/app/src/main/res/values/integers.xml
@@ -1,5 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <!-- General -->
+    <integer name="general.animations_durations.fragment_transition">300</integer>
+
+
     <!-- Main activity -->
     <integer name="activity_main.animations_durations.posters_appearance">300</integer>
     <integer name="activity_main.animations_durations.poster_transition">350</integer>

--- a/app/src/main/res/values/integers.xml
+++ b/app/src/main/res/values/integers.xml
@@ -3,6 +3,9 @@
     <!-- Main activity -->
     <integer name="activity_main.animations_durations.posters_appearance">300</integer>
     <integer name="activity_main.animations_durations.poster_transition">350</integer>
+    <integer name="activity_main.animations_durations.first_appearance.recycler">700</integer>
+    <integer name="activity_main.animations_durations.first_appearance.app_bar">500</integer>
+    <integer name="activity_main.animations_durations.first_appearance.navigation_bar">400</integer>
 
 
     <!-- Favorites fragment -->


### PR DESCRIPTION
Появились анимации переходов между экранами(деталей, избранного, главного списка). При старте приложения воспроизводится одноразовая анимация появления списка и панелей навигации.
Сохраняется состояние app bar (свёрнут/развёрнут), в горизонтальной ориентации он всегда развёрнут. Также его состояние учитывается при переходах между фрагментами.

https://user-images.githubusercontent.com/27242252/226000826-764a5b20-7338-401a-85e9-48c2157d18a7.mp4

