### PR TITLE
Transition from Thread allocation via Executors to Coroutines

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -46,7 +46,7 @@ android {
 dependencies {
 
     // Room
-    def roomVersion = "2.5.1"
+    def roomVersion = "2.5.2"
     implementation "androidx.room:room-runtime:$roomVersion"
     kapt "androidx.room:room-compiler:$roomVersion"
 
@@ -77,6 +77,8 @@ dependencies {
     implementation 'androidx.core:core-ktx:1.10.1'
     implementation 'androidx.appcompat:appcompat:1.6.1'
     implementation 'com.google.android.material:material:1.9.0'
+    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.6.1'
+    implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1'
     implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0"
     implementation 'androidx.recyclerview:recyclerview:1.3.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'

--- a/app/src/main/java/com/sandev/moviesearcher/data/repositories/MoviesListRepositoryImpl.kt
+++ b/app/src/main/java/com/sandev/moviesearcher/data/repositories/MoviesListRepositoryImpl.kt
@@ -13,32 +13,30 @@ import com.sandev.moviesearcher.data.db.entities.PlayingMovie
 import com.sandev.moviesearcher.data.db.entities.PopularMovie
 import com.sandev.moviesearcher.data.db.entities.TopMovie
 import com.sandev.moviesearcher.data.db.entities.UpcomingMovie
-import java.util.concurrent.Executors
 
 
 open class MoviesListRepositoryImpl(private val movieDao: MovieDao) : MoviesListRepository {
 
     @Suppress("UNCHECKED_CAST")
     override fun putToDB(movies: List<Movie>) {
-        Executors.newSingleThreadExecutor().execute {
-            when (movieDao) {
-                is PlayingMovieDao  -> movieDao.putToCachedMovies(movies as List<PlayingMovie>)
-                is PopularMovieDao  -> movieDao.putToCachedMovies(movies as List<PopularMovie>)
-                is TopMovieDao      -> movieDao.putToCachedMovies(movies as List<TopMovie>)
-                is UpcomingMovieDao -> movieDao.putToCachedMovies(movies as List<UpcomingMovie>)
-                is FavoriteMovieDao, is WatchLaterMovieDao -> {
-                    movies.forEach {
-                        movieDao.putToCachedMovies(
-                            poster = it.poster, title = it.title,
-                            description = it.description, rating = it.rating
-                        )
-                    }
+        when (movieDao) {
+            is PlayingMovieDao  -> movieDao.putToCachedMovies(movies as List<PlayingMovie>)
+            is PopularMovieDao  -> movieDao.putToCachedMovies(movies as List<PopularMovie>)
+            is TopMovieDao      -> movieDao.putToCachedMovies(movies as List<TopMovie>)
+            is UpcomingMovieDao -> movieDao.putToCachedMovies(movies as List<UpcomingMovie>)
+            is FavoriteMovieDao, is WatchLaterMovieDao -> {
+                movies.forEach {
+                    movieDao.putToCachedMovies(
+                        poster = it.poster, title = it.title,
+                        description = it.description, rating = it.rating
+                    )
                 }
             }
         }
     }
 
-    override fun getAllFromDB(): LiveData<List<Movie>> = movieDao.getAllCachedMovies()
+    override fun getAllFromDB(): LiveData<List<Movie>>
+            = movieDao.getAllCachedMovies()
 
     override fun getFromDB(moviesCount: Int): LiveData<List<Movie>>
             = movieDao.getLastFewCachedMovies(moviesCount)
@@ -46,7 +44,8 @@ open class MoviesListRepositoryImpl(private val movieDao: MovieDao) : MoviesList
     override fun getFromDB(from: Int, moviesCount: Int): List<Movie>
             = movieDao.getFewCachedMoviesFromOffset(from, moviesCount)
 
-    override fun getSearchedFromDB(query: String): LiveData<List<Movie>> = movieDao.getAllSearchedCachedMovies(query)
+    override fun getSearchedFromDB(query: String): LiveData<List<Movie>>
+            = movieDao.getAllSearchedCachedMovies(query)
 
     override fun getSearchedFromDB(query: String, from: Int, moviesCount: Int): List<Movie>
             = movieDao.getFewSearchedCachedMoviesFromOffset(query, from, moviesCount)
@@ -55,20 +54,16 @@ open class MoviesListRepositoryImpl(private val movieDao: MovieDao) : MoviesList
             = movieDao.getLastFewSearchedCachedMovies(query, moviesCount)
 
     override fun deleteAllFromDB() {
-        Executors.newSingleThreadExecutor().execute {
-            movieDao.deleteAllCachedMovies()
-        }
+        movieDao.deleteAllCachedMovies()
     }
 
     @Suppress("UNCHECKED_CAST")
     override fun deleteAllFromDBAndPutNew(movies: List<Movie>) {
-        Executors.newSingleThreadExecutor().execute {
-            when (movieDao) {
-                is PlayingMovieDao  -> movieDao.deleteAllCachedMoviesAndPutNewMovies(movies as List<PlayingMovie>)
-                is PopularMovieDao  -> movieDao.deleteAllCachedMoviesAndPutNewMovies(movies as List<PopularMovie>)
-                is TopMovieDao      -> movieDao.deleteAllCachedMoviesAndPutNewMovies(movies as List<TopMovie>)
-                is UpcomingMovieDao -> movieDao.deleteAllCachedMoviesAndPutNewMovies(movies as List<UpcomingMovie>)
-            }
+        when (movieDao) {
+            is PlayingMovieDao  -> movieDao.deleteAllCachedMoviesAndPutNewMovies(movies as List<PlayingMovie>)
+            is PopularMovieDao  -> movieDao.deleteAllCachedMoviesAndPutNewMovies(movies as List<PopularMovie>)
+            is TopMovieDao      -> movieDao.deleteAllCachedMoviesAndPutNewMovies(movies as List<TopMovie>)
+            is UpcomingMovieDao -> movieDao.deleteAllCachedMoviesAndPutNewMovies(movies as List<UpcomingMovie>)
         }
     }
 }

--- a/app/src/main/java/com/sandev/moviesearcher/data/repositories/MoviesListRepositoryImplForSavedLists.kt
+++ b/app/src/main/java/com/sandev/moviesearcher/data/repositories/MoviesListRepositoryImplForSavedLists.kt
@@ -3,17 +3,14 @@ package com.sandev.moviesearcher.data.repositories
 import com.sandev.moviesearcher.data.db.dao.SavedMovieDao
 import com.sandev.moviesearcher.data.db.entities.Movie
 import com.sandev.moviesearcher.data.db.entities.TitleAndDescription
-import java.util.concurrent.Executors
 
 
 class MoviesListRepositoryImplForSavedLists(private val savedMovieDao: SavedMovieDao)
     : MoviesListRepositoryImpl(savedMovieDao) {
 
     fun deleteFromDB(movie: Movie) {
-        Executors.newSingleThreadExecutor().execute {
-            savedMovieDao.deleteFromCachedMovies(
-                TitleAndDescription(title = movie.title, description = movie.description)
-            )
-        }
+        savedMovieDao.deleteFromCachedMovies(
+            TitleAndDescription(title = movie.title, description = movie.description)
+        )
     }
 }

--- a/app/src/main/java/com/sandev/moviesearcher/data/themoviedatabase/TmdbApi.kt
+++ b/app/src/main/java/com/sandev/moviesearcher/data/themoviedatabase/TmdbApi.kt
@@ -1,6 +1,5 @@
 package com.sandev.moviesearcher.data.themoviedatabase
 
-import retrofit2.Call
 import retrofit2.http.GET
 import retrofit2.http.Path
 import retrofit2.http.Query
@@ -8,18 +7,18 @@ import retrofit2.http.Query
 
 interface TmdbApi {
     @GET("movie/{category}")
-    fun getMovies(
+    suspend fun getMovies(
         @Path("category") category: String,
         @Query("api_key") apiKey: String,
         @Query("language") language: String,
         @Query("page") page: Int
-    ): Call<TmdbResultDto>
+    ): TmdbResultDto
 
     @GET("search/movie")
-    fun getSearchedMovies(
+    suspend fun getSearchedMovies(
         @Query("api_key") apiKey: String,
         @Query("query") query: String,
         @Query("language") language: String,
         @Query("page") page: Int
-    ): Call<TmdbResultDto>
+    ): TmdbResultDto
 }

--- a/app/src/main/java/com/sandev/moviesearcher/data/themoviedatabase/TmdbResult.kt
+++ b/app/src/main/java/com/sandev/moviesearcher/data/themoviedatabase/TmdbResult.kt
@@ -1,0 +1,9 @@
+package com.sandev.moviesearcher.data.themoviedatabase
+
+import com.sandev.moviesearcher.data.db.entities.Movie
+
+
+data class TmdbResult(
+    val movies: List<Movie>,
+    val totalPages: Int
+)

--- a/app/src/main/java/com/sandev/moviesearcher/domain/interactors/MoviesListInteractor.kt
+++ b/app/src/main/java/com/sandev/moviesearcher/domain/interactors/MoviesListInteractor.kt
@@ -5,6 +5,8 @@ import androidx.lifecycle.MutableLiveData
 import com.sandev.moviesearcher.data.db.entities.Movie
 import com.sandev.moviesearcher.data.repositories.MoviesListRepository
 import com.sandev.moviesearcher.data.repositories.MoviesListRepositoryImplForSavedLists
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import java.util.Locale
 import javax.inject.Inject
 
@@ -20,29 +22,29 @@ class MoviesListInteractor @Inject constructor(private val repo: MoviesListRepos
     val getMovieAddedNotify: LiveData<Nothing> = movieAddedNotify
 
 
-    fun addToList(movie: Movie) {
+    suspend fun addToList(movie: Movie) = withContext(Dispatchers.IO) {
         repo.putToDB(listOf(movie))
         movieAddedNotify.postValue(null)
     }
 
-    fun removeFromList(movie: Movie) {
+    suspend fun removeFromList(movie: Movie) = withContext(Dispatchers.IO) {
         (repo as MoviesListRepositoryImplForSavedLists).deleteFromDB(movie)
         deletedMovie.postValue(movie)
     }
 
-    fun getAllFromList(): LiveData<List<Movie>> = repo.getAllFromDB()
+    suspend fun getAllFromList(): LiveData<List<Movie>> = withContext(Dispatchers.IO) {
+        repo.getAllFromDB()
+    }
 
-    fun getFewMoviesFromList(from: Int, moviesCount: Int): List<Movie> = repo.getFromDB(
-        from = from,
-        moviesCount = moviesCount
-    )
+    suspend fun getFewMoviesFromList(from: Int, moviesCount: Int): List<Movie>
+            = withContext(Dispatchers.IO) {
+        repo.getFromDB(from = from, moviesCount = moviesCount)
+    }
 
-    fun getFewSearchedMoviesFromList(query: String, from: Int, moviesCount: Int): List<Movie>
-            = repo.getSearchedFromDB(
-        query = query,
-        from = from,
-        moviesCount = moviesCount
-    )
+    suspend fun getFewSearchedMoviesFromList(query: String, from: Int, moviesCount: Int): List<Movie>
+            = withContext(Dispatchers.IO) {
+        repo.getSearchedFromDB(query = query, from = from, moviesCount = moviesCount)
+    }
 
 
     companion object {

--- a/app/src/main/java/com/sandev/moviesearcher/domain/interactors/MoviesListInteractor.kt
+++ b/app/src/main/java/com/sandev/moviesearcher/domain/interactors/MoviesListInteractor.kt
@@ -15,10 +15,10 @@ class MoviesListInteractor @Inject constructor(private val repo: MoviesListRepos
 
     override val systemLanguage = Locale.getDefault().toLanguageTag()
 
-    val deletedMovie = MutableLiveData<Movie>()
+    private val deletedMovie = MutableLiveData<Movie>()
     val getDeletedMovie: LiveData<Movie> = deletedMovie
 
-    val movieAddedNotify = MutableLiveData<Nothing>()
+    private val movieAddedNotify = MutableLiveData<Nothing>()
     val getMovieAddedNotify: LiveData<Nothing> = movieAddedNotify
 
 

--- a/app/src/main/java/com/sandev/moviesearcher/domain/interactors/SharedPreferencesInteractor.kt
+++ b/app/src/main/java/com/sandev/moviesearcher/domain/interactors/SharedPreferencesInteractor.kt
@@ -2,13 +2,19 @@ package com.sandev.moviesearcher.domain.interactors
 
 import android.content.SharedPreferences.OnSharedPreferenceChangeListener
 import com.sandev.moviesearcher.data.SharedPreferencesProvider
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
 
 class SharedPreferencesInteractor(private val sharedPreferences: SharedPreferencesProvider) {
 
-    fun setDefaultMoviesCategoryInMainList(category: String) = sharedPreferences.setDefaultCategory(category)
+    suspend fun setDefaultMoviesCategoryInMainList(category: String) = withContext(Dispatchers.IO) {
+        sharedPreferences.setDefaultCategory(category)
+    }
 
-    fun getDefaultMoviesCategoryInMainList() = sharedPreferences.getDefaultCategory()
+    suspend fun getDefaultMoviesCategoryInMainList() = withContext(Dispatchers.IO) {
+        sharedPreferences.getDefaultCategory()
+    }
 
     fun addSharedPreferencesChangeListener(listener: OnSharedPreferenceChangeListener) =
         sharedPreferences.registerSharedPreferencesChangeListener(listener)

--- a/app/src/main/java/com/sandev/moviesearcher/domain/interactors/TmdbInteractor.kt
+++ b/app/src/main/java/com/sandev/moviesearcher/domain/interactors/TmdbInteractor.kt
@@ -11,6 +11,8 @@ import com.sandev.moviesearcher.data.themoviedatabase.TmdbApiKey
 import com.sandev.moviesearcher.data.themoviedatabase.TmdbResultDto
 import com.sandev.moviesearcher.utils.TmdbConverter
 import com.sandev.moviesearcher.view.viewmodels.MoviesListFragmentViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import retrofit2.Call
 import retrofit2.Callback
 import retrofit2.Response
@@ -43,8 +45,9 @@ class TmdbInteractor(private val retrofitService: TmdbApi,
     }
 
 
-    fun getMoviesFromApi(page: Int, callback: MoviesListFragmentViewModel.ApiCallback,
-                         repositoryType: RepositoryType, isNeededWipeBeforePutData: Boolean) {
+    suspend fun getMoviesFromApi(page: Int, callback: MoviesListFragmentViewModel.ApiCallback,
+                         repositoryType: RepositoryType, isNeededWipeBeforePutData: Boolean)
+            = withContext(Dispatchers.IO) {
         retrofitService.getMovies(
             apiKey = TmdbApiKey.KEY,
             category = sharedPreferences.getDefaultCategory(),
@@ -57,7 +60,8 @@ class TmdbInteractor(private val retrofitService: TmdbApi,
         ))
     }
 
-    fun getSearchedMoviesFromApi(query: String, page: Int, callback: MoviesListFragmentViewModel.ApiCallback) {
+    suspend fun getSearchedMoviesFromApi(query: String, page: Int, callback: MoviesListFragmentViewModel.ApiCallback)
+            = withContext(Dispatchers.IO){
         retrofitService.getSearchedMovies(
             apiKey = TmdbApiKey.KEY,
             query = query,
@@ -66,18 +70,22 @@ class TmdbInteractor(private val retrofitService: TmdbApi,
         ).enqueue(RetrofitTmdbCallback(callback))
     }
 
-    fun getMoviesFromDB(page: Int, moviesPerPage: Int, repositoryType: RepositoryType)
-            = getRequestedRepository(repositoryType).getFromDB(
-        from = (page - 1) * moviesPerPage,
-        moviesCount = moviesPerPage
-    )
+    suspend fun getMoviesFromDB(page: Int, moviesPerPage: Int, repositoryType: RepositoryType)
+            = withContext(Dispatchers.IO) {
+        getRequestedRepository(repositoryType).getFromDB(
+            from = (page - 1) * moviesPerPage,
+            moviesCount = moviesPerPage
+        )
+    }
 
-    fun getSearchedMoviesFromDB(query: String, page: Int, moviesPerPage: Int, repositoryType: RepositoryType)
-            = getRequestedRepository(repositoryType).getSearchedFromDB(
-        query = query,
-        from = (page - 1) * moviesPerPage,
-        moviesCount = moviesPerPage
-    )
+    suspend fun getSearchedMoviesFromDB(query: String, page: Int, moviesPerPage: Int, repositoryType: RepositoryType)
+            = withContext(Dispatchers.IO) {
+        getRequestedRepository(repositoryType).getSearchedFromDB(
+            query = query,
+            from = (page - 1) * moviesPerPage,
+            moviesCount = moviesPerPage
+        )
+    }
 
     private fun getRequestedRepository(repositoryType: RepositoryType): MoviesListRepository {
         return when (repositoryType) {

--- a/app/src/main/java/com/sandev/moviesearcher/utils/AlertDialogExtensions.kt
+++ b/app/src/main/java/com/sandev/moviesearcher/utils/AlertDialogExtensions.kt
@@ -1,0 +1,25 @@
+package com.sandev.moviesearcher.utils
+
+import android.content.DialogInterface
+import android.view.Gravity
+import android.widget.LinearLayout
+import androidx.appcompat.app.AlertDialog
+import com.sandev.moviesearcher.R
+
+
+fun AlertDialog.changeAppearanceToSamsungOneUI(): AlertDialog {
+    window?.setGravity(Gravity.BOTTOM)
+    window?.setBackgroundDrawableResource(R.drawable.alert_dialog_background)
+
+    show()  // Без show() getButton выдаст null
+    val negativeButton = getButton(DialogInterface.BUTTON_NEGATIVE)
+    dismiss()
+
+    val buttonNewLayoutParams = LinearLayout.LayoutParams(
+        LinearLayout.LayoutParams.MATCH_PARENT,
+        LinearLayout.LayoutParams.WRAP_CONTENT
+    )
+    negativeButton.layoutParams = buttonNewLayoutParams
+
+    return this
+}

--- a/app/src/main/java/com/sandev/moviesearcher/utils/CircularRevealAnimator.kt
+++ b/app/src/main/java/com/sandev/moviesearcher/utils/CircularRevealAnimator.kt
@@ -20,10 +20,6 @@ class CircularRevealAnimator(private val windowHeight: Int, private val windowWi
 
     var animationDuration = DEFAULT_ANIMATION_DURATION
 
-    companion object {
-        const val DEFAULT_ANIMATION_DURATION = 400L
-    }
-
 
     fun revealView() {
         if (!isAnimationActive) {
@@ -34,7 +30,6 @@ class CircularRevealAnimator(private val windowHeight: Int, private val windowWi
             }
         }
     }
-
 
     private fun reveal() {
         val startRadius = 0f
@@ -58,7 +53,6 @@ class CircularRevealAnimator(private val windowHeight: Int, private val windowWi
                 revealingView, targetX, targetY, startRadius, endRadius).apply {
             duration = animationDuration
             interpolator = outInterpolator
-            interpolator
             addListener(animationListener)
             start()
         }
@@ -80,5 +74,10 @@ class CircularRevealAnimator(private val windowHeight: Int, private val windowWi
 
         override fun onAnimationCancel(animation: Animator) {}
         override fun onAnimationRepeat(animation: Animator) {}
+    }
+
+
+    companion object {
+        const val DEFAULT_ANIMATION_DURATION = 400L
     }
 }

--- a/app/src/main/java/com/sandev/moviesearcher/utils/TmdbConverter.kt
+++ b/app/src/main/java/com/sandev/moviesearcher/utils/TmdbConverter.kt
@@ -1,5 +1,6 @@
 package com.sandev.moviesearcher.utils
 
+import com.sandev.moviesearcher.data.db.entities.Movie
 import com.sandev.moviesearcher.data.db.entities.PlayingMovie
 import com.sandev.moviesearcher.data.db.entities.PopularMovie
 import com.sandev.moviesearcher.data.db.entities.TopMovie
@@ -55,6 +56,21 @@ object TmdbConverter {
 
     fun convertApiDtoListToUpcomingMovieList(list: List<TmdbMovieDto>?): List<UpcomingMovie> {
         val result = mutableListOf<UpcomingMovie>()
+        list?.forEach { tmdbMovie ->
+            result.add(
+                UpcomingMovie(
+                    poster = tmdbMovie.posterPath,
+                    title = tmdbMovie.title,
+                    description = tmdbMovie.overview,
+                    rating = tmdbMovie.voteAverage
+                )
+            )
+        }
+        return result
+    }
+
+    fun convertApiDtoListToMovieList(list: List<TmdbMovieDto>?): List<Movie> {
+        val result = mutableListOf<Movie>()
         list?.forEach { tmdbMovie ->
             result.add(
                 UpcomingMovie(

--- a/app/src/main/java/com/sandev/moviesearcher/view/MainActivity.kt
+++ b/app/src/main/java/com/sandev/moviesearcher/view/MainActivity.kt
@@ -8,7 +8,6 @@ import android.view.MenuItem
 import android.view.View
 import android.view.ViewOutlineProvider
 import android.view.animation.DecelerateInterpolator
-import android.widget.ImageView
 import android.widget.Toast
 import androidx.activity.OnBackPressedCallback
 import androidx.appcompat.app.AppCompatActivity
@@ -23,6 +22,7 @@ import androidx.core.view.updatePadding
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import androidx.lifecycle.lifecycleScope
+import com.google.android.material.imageview.ShapeableImageView
 import com.sandev.moviesearcher.R
 import com.sandev.moviesearcher.data.db.entities.Movie
 import com.sandev.moviesearcher.databinding.ActivityMainBinding
@@ -200,7 +200,7 @@ class MainActivity : AppCompatActivity() {
         }
     }
 
-    fun startDetailsFragment(movie: Movie, posterView: ImageView) {
+    fun startDetailsFragment(movie: Movie, posterView: ShapeableImageView) {
         val bundle = Bundle()
         bundle.putParcelable(MOVIE_DATA_KEY, movie)
         val transitionName = posterView.transitionName
@@ -213,6 +213,7 @@ class MainActivity : AppCompatActivity() {
         previousFragmentName = supportFragmentManager.fragments.last()::class.qualifiedName
         supportFragmentManager
             .beginTransaction()
+            .setReorderingAllowed(true)
             .addSharedElement(posterView, transitionName)
             .replace(R.id.fragment, detailsFragment)
             .addToBackStack(null)

--- a/app/src/main/java/com/sandev/moviesearcher/view/customviews/RatingDonutView.kt
+++ b/app/src/main/java/com/sandev/moviesearcher/view/customviews/RatingDonutView.kt
@@ -18,6 +18,7 @@ import com.sandev.moviesearcher.R
 
 class RatingDonutView @JvmOverloads constructor(context: Context, attrs: AttributeSet? = null)
     : View(context, attrs) {
+
     private val oval = RectF()
     private val textRect = Rect()
 
@@ -78,6 +79,13 @@ class RatingDonutView @JvmOverloads constructor(context: Context, attrs: Attribu
         private val RATING_RANGE_NEUTRAL   = 40 .. 59
         private val RATING_RANGE_GOOD      = 60 .. 79
         private val RATING_RANGE_EXCELLENT = 80 .. FULL_PROGRESS
+
+        private var isColorsInitialized = false
+        private var RATING_COLOR_AWFUL:     Int? = null
+        private var RATING_COLOR_BAD:       Int? = null
+        private var RATING_COLOR_NEUTRAL:   Int? = null
+        private var RATING_COLOR_GOOD:      Int? = null
+        private var RATING_COLOR_EXCELLENT: Int? = null
     }
 
 
@@ -99,8 +107,13 @@ class RatingDonutView @JvmOverloads constructor(context: Context, attrs: Attribu
         progressAnimation = factualProgress
         displayingProgress = factualProgress.toFloat()
 
+        if (!isColorsInitialized) {
+            initColors()
+        }
+
         initPaint()
     }
+
 
     override fun onSizeChanged(width: Int, height: Int, oldWidth: Int, oldHeight: Int) {
         radius = if (width > height) {
@@ -220,12 +233,11 @@ class RatingDonutView @JvmOverloads constructor(context: Context, attrs: Attribu
             invalidate()
 
             if (progressAnimation < factualProgress) {
+                ++progressAnimation
                 postDelayed(ANIMATION_ITERATION_DELAY) { increaseProgress() }
             } else {
                 isAnimationRunning = false
             }
-
-            ++progressAnimation
         }
 
         increaseProgress()
@@ -258,17 +270,27 @@ class RatingDonutView @JvmOverloads constructor(context: Context, attrs: Attribu
         }
     }
 
+    private fun initColors() {
+        RATING_COLOR_AWFUL     = RATING_COLOR_AWFUL     ?: resources.getColor(R.color.rating_color_awful, context.theme)
+        RATING_COLOR_BAD       = RATING_COLOR_BAD       ?: resources.getColor(R.color.rating_color_bad, context.theme)
+        RATING_COLOR_NEUTRAL   = RATING_COLOR_NEUTRAL   ?: resources.getColor(R.color.rating_color_neutral, context.theme)
+        RATING_COLOR_GOOD      = RATING_COLOR_GOOD      ?: resources.getColor(R.color.rating_color_good, context.theme)
+        RATING_COLOR_EXCELLENT = RATING_COLOR_EXCELLENT ?: resources.getColor(R.color.rating_color_excellent, context.theme)
+
+        isColorsInitialized = true
+    }
+
     private fun updatePaintsColors() {
         strokePaint.color = getPaintColor(displayingProgress.toInt())
         digitPaint.color = getPaintColor(displayingProgress.toInt())
     }
 
     private fun getPaintColor(progress: Int) = when (progress) {
-        in RATING_RANGE_AWFUL     -> resources.getColor(R.color.rating_color_awful, context.theme)
-        in RATING_RANGE_BAD       -> resources.getColor(R.color.rating_color_bad, context.theme)
-        in RATING_RANGE_NEUTRAL   -> resources.getColor(R.color.rating_color_neutral, context.theme)
-        in RATING_RANGE_GOOD      -> resources.getColor(R.color.rating_color_good, context.theme)
-        in RATING_RANGE_EXCELLENT -> resources.getColor(R.color.rating_color_excellent, context.theme)
+        in RATING_RANGE_AWFUL     -> RATING_COLOR_AWFUL!!
+        in RATING_RANGE_BAD       -> RATING_COLOR_BAD!!
+        in RATING_RANGE_NEUTRAL   -> RATING_COLOR_NEUTRAL!!
+        in RATING_RANGE_GOOD      -> RATING_COLOR_GOOD!!
+        in RATING_RANGE_EXCELLENT -> RATING_COLOR_EXCELLENT!!
         else -> Color.DKGRAY
     }
 }

--- a/app/src/main/java/com/sandev/moviesearcher/view/fragments/DetailsFragment.kt
+++ b/app/src/main/java/com/sandev/moviesearcher/view/fragments/DetailsFragment.kt
@@ -51,6 +51,7 @@ import com.sandev.moviesearcher.data.themoviedatabase.TmdbApiConstants.IMAGES_UR
 import com.sandev.moviesearcher.data.themoviedatabase.TmdbApiConstants.IMAGE_HIGH_SIZE
 import com.sandev.moviesearcher.data.themoviedatabase.TmdbApiConstants.IMAGE_MEDIUM_SIZE
 import com.sandev.moviesearcher.databinding.FragmentDetailsBinding
+import com.sandev.moviesearcher.utils.changeAppearanceToSamsungOneUI
 import com.sandev.moviesearcher.view.MainActivity
 import com.sandev.moviesearcher.view.viewmodels.DetailsFragmentViewModel
 import kotlinx.coroutines.CancellationException
@@ -391,19 +392,7 @@ class DetailsFragment : Fragment() {
                 dialogInterface.dismiss()
             }
             .create()
-
-        alertDialog.window?.setGravity(Gravity.BOTTOM)
-        alertDialog.window?.setBackgroundDrawableResource(R.drawable.alert_dialog_background)
-
-        alertDialog.show()  // Без show() getButton выдаст null
-        val negativeButton = alertDialog.getButton(DialogInterface.BUTTON_NEGATIVE)
-        alertDialog.dismiss()
-
-        val buttonNewLayoutParams = LinearLayout.LayoutParams(
-            LinearLayout.LayoutParams.MATCH_PARENT,
-            LinearLayout.LayoutParams.WRAP_CONTENT
-        )
-        negativeButton.layoutParams = buttonNewLayoutParams
+            .changeAppearanceToSamsungOneUI()
 
         initializeDialogButtons(alertDialog)
 

--- a/app/src/main/java/com/sandev/moviesearcher/view/fragments/DetailsFragment.kt
+++ b/app/src/main/java/com/sandev/moviesearcher/view/fragments/DetailsFragment.kt
@@ -248,6 +248,7 @@ class DetailsFragment : Fragment() {
                         .load("${IMAGES_URL}${IMAGE_MEDIUM_SIZE}${viewModel.movie.poster}")
                         .placeholder(R.drawable.dummy_poster)
                         .apply(RequestOptions().dontTransform())
+                        .onlyRetrieveFromCache(true)
                         .listener(object : RequestListener<Drawable>{  // Подождать полной загрузки из кэша и только потом делать перенос постера
                             override fun onLoadFailed(e: GlideException?, model: Any?, target: Target<Drawable>?, isFirstResource: Boolean): Boolean {
                                 startPostponedEnterTransition()
@@ -262,7 +263,9 @@ class DetailsFragment : Fragment() {
                 } else {
                     Glide.with(this@DetailsFragment)
                         .load(R.drawable.dummy_poster)
+                        .apply(RequestOptions().dontTransform())
                         .into(this)
+                    doOnPreDraw { startPostponedEnterTransition() }
                 }
                 transitionName = arguments?.getString(MainActivity.POSTER_TRANSITION_KEY)
             }

--- a/app/src/main/java/com/sandev/moviesearcher/view/fragments/DetailsFragment.kt
+++ b/app/src/main/java/com/sandev/moviesearcher/view/fragments/DetailsFragment.kt
@@ -2,7 +2,6 @@ package com.sandev.moviesearcher.view.fragments
 
 import android.Manifest
 import android.content.ContentValues
-import android.content.DialogInterface
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.graphics.Bitmap
@@ -19,7 +18,6 @@ import android.view.ViewGroup
 import android.view.ViewOutlineProvider
 import android.view.animation.DecelerateInterpolator
 import android.widget.Button
-import android.widget.LinearLayout
 import androidx.appcompat.app.AlertDialog
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
@@ -35,6 +33,7 @@ import androidx.fragment.app.Fragment
 import androidx.interpolator.view.animation.FastOutLinearInInterpolator
 import androidx.interpolator.view.animation.LinearOutSlowInInterpolator
 import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.lifecycleScope
 import androidx.transition.Fade
 import androidx.transition.Slide
 import androidx.transition.TransitionInflater
@@ -179,10 +178,13 @@ class DetailsFragment : Fragment() {
         checkWatchLaterFloatButtonState()
     }
 
-    private fun checkFavoriteFloatButtonState() {
-        viewModel.getFavoritesMovies.observe(viewLifecycleOwner) { favoritesMovies ->
-            if (favoritesMovies.find { it.title == viewModel.movie.title
-                        && it.description == viewModel.movie.description } != null) {
+    private fun checkFavoriteFloatButtonState() = viewLifecycleOwner.lifecycleScope.launch {
+        viewModel.favoritesMoviesObtainSynchronizeBlock.receiveCatching()
+        viewModel.getFavoritesMovies!!.observe(viewLifecycleOwner) { favoritesMovies ->
+            val existedFavoriteMovie: Movie? = favoritesMovies.find {
+                it.title == viewModel.movie.title && it.description == viewModel.movie.description
+            }
+            if (existedFavoriteMovie != null) {
                 viewModel.isFavoriteMovie = true
                 binding.fabToFavorite.isSelected = true
                 binding.fabToFavorite.setImageResource(R.drawable.favorite_icon_selector)
@@ -190,10 +192,14 @@ class DetailsFragment : Fragment() {
         }
     }
 
-    private fun checkWatchLaterFloatButtonState() {
-        viewModel.getWatchLaterMovies.observe(viewLifecycleOwner) { watchLaterMovies ->
-            if (watchLaterMovies.find { it.title == viewModel.movie.title
-                        && it.description == viewModel.movie.description } != null) {
+
+    private fun checkWatchLaterFloatButtonState() = viewLifecycleOwner.lifecycleScope.launch {
+        viewModel.watchLaterMoviesObtainSynchronizeBlock.receiveCatching()
+        viewModel.getWatchLaterMovies!!.observe(viewLifecycleOwner) { watchLaterMovies ->
+            val existedWatchLaterMovie: Movie? = watchLaterMovies.find {
+                it.title == viewModel.movie.title && it.description == viewModel.movie.description
+            }
+            if (existedWatchLaterMovie != null) {
                 viewModel.isWatchLaterMovie = true
                 binding.fabToWatchLater.isSelected = true
                 binding.fabToWatchLater.setImageResource(R.drawable.watch_later_icon_selector)

--- a/app/src/main/java/com/sandev/moviesearcher/view/fragments/FavoritesFragment.kt
+++ b/app/src/main/java/com/sandev/moviesearcher/view/fragments/FavoritesFragment.kt
@@ -7,11 +7,10 @@ import android.view.View
 import android.view.ViewGroup
 import android.view.animation.Animation
 import android.view.animation.AnimationUtils
-import android.widget.ImageView
 import androidx.core.view.doOnPreDraw
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
-import androidx.transition.TransitionInflater
+import com.google.android.material.imageview.ShapeableImageView
 import com.sandev.moviesearcher.R
 import com.sandev.moviesearcher.data.db.entities.Movie
 import com.sandev.moviesearcher.databinding.FragmentFavoritesBinding
@@ -19,15 +18,9 @@ import com.sandev.moviesearcher.utils.rv_animators.MovieItemAnimator
 import com.sandev.moviesearcher.view.MainActivity
 import com.sandev.moviesearcher.view.rv_adapters.MoviesRecyclerAdapter
 import com.sandev.moviesearcher.view.viewmodels.FavoritesFragmentViewModel
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.NonCancellable
-import kotlinx.coroutines.cancel
-import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.withContext
-import kotlin.coroutines.EmptyCoroutineContext
 
 
 class FavoritesFragment : MoviesListFragment() {
@@ -43,7 +36,7 @@ class FavoritesFragment : MoviesListFragment() {
     private var mainActivity: MainActivity? = null
 
     private val posterOnClick = object : MoviesRecyclerAdapter.OnClickListener {
-        override fun onClick(movie: Movie, posterView: ImageView) {
+        override fun onClick(movie: Movie, posterView: ShapeableImageView) {
             resetExitReenterTransitionAnimations()
             viewModel.lastClickedMovie = movie
             mainActivity?.startDetailsFragment(movie, posterView)
@@ -103,7 +96,6 @@ class FavoritesFragment : MoviesListFragment() {
     private fun setAllAnimationTransition() {
         setTransitionAnimation(Gravity.END)
 
-        sharedElementReturnTransition = TransitionInflater.from(context).inflateTransition(R.transition.poster_transition)
         postponeEnterTransition()  // не запускать анимацию возвращения постера в список пока не просчитается recycler
 
         if (mainActivity?.previousFragmentName == DetailsFragment::class.qualifiedName) {

--- a/app/src/main/java/com/sandev/moviesearcher/view/fragments/FavoritesFragment.kt
+++ b/app/src/main/java/com/sandev/moviesearcher/view/fragments/FavoritesFragment.kt
@@ -19,8 +19,15 @@ import com.sandev.moviesearcher.utils.rv_animators.MovieItemAnimator
 import com.sandev.moviesearcher.view.MainActivity
 import com.sandev.moviesearcher.view.rv_adapters.MoviesRecyclerAdapter
 import com.sandev.moviesearcher.view.viewmodels.FavoritesFragmentViewModel
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
+import kotlin.coroutines.EmptyCoroutineContext
 
 
 class FavoritesFragment : MoviesListFragment() {
@@ -52,6 +59,8 @@ class FavoritesFragment : MoviesListFragment() {
 
         mainActivity = activity as MainActivity
 
+        viewModel.isMovieMoreNotInSavedList = false
+
         initializeViewsReferences(binding.root)
         setAllAnimationTransition()
 
@@ -71,6 +80,10 @@ class FavoritesFragment : MoviesListFragment() {
 
     override fun onDestroyView() {
         super.onDestroyView()
+
+        runBlocking {  // Если пользователь быстро нажимал "назад", то это предотвращает неудаление карточки
+            viewModel.checkForMovieDeletionNecessary()
+        }
 
         _binding = null
     }
@@ -103,6 +116,7 @@ class FavoritesFragment : MoviesListFragment() {
                 override fun onAnimationStart(animation: Animation?) {}
                 override fun onAnimationRepeat(animation: Animation?) {}
                 override fun onAnimationEnd(animation: Animation) {
+                    if (view == null) return
                     viewLifecycleOwner.lifecycleScope.launch {
                         launch {
                             binding.moviesListRecycler.layoutAnimationListener = null

--- a/app/src/main/java/com/sandev/moviesearcher/view/fragments/HomeFragment.kt
+++ b/app/src/main/java/com/sandev/moviesearcher/view/fragments/HomeFragment.kt
@@ -9,16 +9,15 @@ import android.view.ViewGroup
 import android.view.animation.Animation
 import android.view.animation.AnimationUtils
 import android.view.animation.DecelerateInterpolator
-import android.widget.ImageView
 import androidx.core.view.doOnPreDraw
 import androidx.fragment.app.FragmentManager.OnBackStackChangedListener
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
 import androidx.transition.Scene
 import androidx.transition.Slide
-import androidx.transition.TransitionInflater
 import androidx.transition.TransitionManager
 import androidx.transition.TransitionSet
+import com.google.android.material.imageview.ShapeableImageView
 import com.google.android.material.snackbar.BaseTransientBottomBar
 import com.google.android.material.snackbar.BaseTransientBottomBar.ANIMATION_MODE_FADE
 import com.google.android.material.snackbar.Snackbar
@@ -109,7 +108,7 @@ class HomeFragment : MoviesListFragment() {
 
     private fun initializeMovieRecycler() {
         viewModel.recyclerAdapter.setPosterOnClickListener(object : MoviesRecyclerAdapter.OnClickListener {
-            override fun onClick(movie: Movie, posterView: ImageView) {
+            override fun onClick(movie: Movie, posterView: ShapeableImageView) {
                 resetExitReenterTransitionAnimations()
                 mainActivity?.startDetailsFragment(movie, posterView)
             }
@@ -202,7 +201,6 @@ class HomeFragment : MoviesListFragment() {
     }
 
     private fun setAllTransitionAnimation() {
-        sharedElementReturnTransition = TransitionInflater.from(context).inflateTransition(R.transition.poster_transition)
         postponeEnterTransition()  // не запускать анимацию возвращения постера в список пока не просчитается recycler
 
         val scene = Scene.getSceneForLayout(bindingBlank.root as ViewGroup, R.layout.merge_fragment_home_content, requireContext())

--- a/app/src/main/java/com/sandev/moviesearcher/view/fragments/MoviesListFragment.kt
+++ b/app/src/main/java/com/sandev/moviesearcher/view/fragments/MoviesListFragment.kt
@@ -153,11 +153,22 @@ abstract class MoviesListFragment : Fragment() {
     }
 
     private fun setupSearchBehavior() {
+        val defaultHint = searchBar.hint?.toString()
+
+        if (viewModel.lastSearch.isNotEmpty()) {
+            searchBar.hint = viewModel.lastSearch
+            searchView.hint = viewModel.lastSearch
+        }
+
         val textChangeListener = object : TextWatcher {
             override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
             override fun afterTextChanged(s: Editable?) {}
 
             override fun onTextChanged(text: CharSequence, start: Int, before: Int, count: Int) {
+                if (text.isEmpty()) {
+                    searchBar.hint = defaultHint
+                    searchView.hint = defaultHint
+                }
                 viewModel.searchInSearchView(text.toString())
             }
         }
@@ -172,6 +183,10 @@ abstract class MoviesListFragment : Fragment() {
                     editText.addTextChangedListener(textChangeListener)
                 } else if (previousState == SearchView.TransitionState.SHOWN &&
                         newState == SearchView.TransitionState.HIDING) {
+                    // Сохранение текста на экране при выходе из ввода
+                    searchBar.hint = text?.ifEmpty { defaultHint }
+                    searchView.hint = text?.ifEmpty { defaultHint }
+
                     editText.removeTextChangedListener(textChangeListener)
                     // Принудительно убрать системную панель навигации на старых андроидах
                     if (resources.configuration.orientation == Configuration.ORIENTATION_LANDSCAPE) {

--- a/app/src/main/java/com/sandev/moviesearcher/view/fragments/SettingsFragment.kt
+++ b/app/src/main/java/com/sandev/moviesearcher/view/fragments/SettingsFragment.kt
@@ -2,9 +2,7 @@ package com.sandev.moviesearcher.view.fragments
 
 import android.animation.AnimatorInflater
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import androidx.activity.OnBackPressedCallback
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
@@ -13,15 +11,15 @@ import androidx.core.view.updatePadding
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
 import com.sandev.moviesearcher.R
+import com.sandev.moviesearcher.data.SharedPreferencesProvider
 import com.sandev.moviesearcher.databinding.FragmentSettingsBinding
 import com.sandev.moviesearcher.view.viewmodels.SettingsFragmentViewModel
 
 
-class SettingsFragment : Fragment() {
+class SettingsFragment : Fragment(R.layout.fragment_settings) {
 
     private val viewModel: SettingsFragmentViewModel by lazy {
-        val factory = SettingsFragmentViewModel.MyViewModelFactory(requireContext())
-        ViewModelProvider(this, factory)[SettingsFragmentViewModel::class.java]
+        ViewModelProvider(this)[SettingsFragmentViewModel::class.java]
     }
 
     private var _binding: FragmentSettingsBinding? = null
@@ -33,13 +31,9 @@ class SettingsFragment : Fragment() {
     }
 
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        _binding = FragmentSettingsBinding.inflate(inflater, container, false)
-
-        return binding.root
-    }
-
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        _binding = FragmentSettingsBinding.bind(view)
+
         setAppBarAppearance()
         setSearchBarAppearance()
         initializeCategoryRadioGroup()
@@ -54,19 +48,19 @@ class SettingsFragment : Fragment() {
     private fun initializeCategoryRadioGroup() {
         viewModel.getCategoryProperty.observe(viewLifecycleOwner) { currentCategory ->
             when (currentCategory) {
-                viewModel.categoryPopular -> binding.categoryRadioGroup.check(R.id.RadioButtonPopular)
-                viewModel.categoryTopRated -> binding.categoryRadioGroup.check(R.id.RadioButtonTopRated)
-                viewModel.categoryUpcoming -> binding.categoryRadioGroup.check(R.id.RadioButtonUpcoming)
-                viewModel.categoryNowPlaying -> binding.categoryRadioGroup.check(R.id.RadioButtonNowPlaying)
+                SharedPreferencesProvider.CATEGORY_TOP      -> binding.categoryRadioGroup.check(R.id.RadioButtonTopRated)
+                SharedPreferencesProvider.CATEGORY_POPULAR  -> binding.categoryRadioGroup.check(R.id.RadioButtonPopular)
+                SharedPreferencesProvider.CATEGORY_UPCOMING -> binding.categoryRadioGroup.check(R.id.RadioButtonUpcoming)
+                SharedPreferencesProvider.CATEGORY_PLAYING  -> binding.categoryRadioGroup.check(R.id.RadioButtonNowPlaying)
             }
         }
 
         binding.categoryRadioGroup.setOnCheckedChangeListener { _, checkedId ->
             when (checkedId) {
-                R.id.RadioButtonPopular -> viewModel.putCategoryProperty(viewModel.categoryPopular)
-                R.id.RadioButtonTopRated -> viewModel.putCategoryProperty(viewModel.categoryTopRated)
-                R.id.RadioButtonUpcoming -> viewModel.putCategoryProperty(viewModel.categoryUpcoming)
-                R.id.RadioButtonNowPlaying -> viewModel.putCategoryProperty(viewModel.categoryNowPlaying)
+                R.id.RadioButtonTopRated   -> viewModel.putCategoryProperty(SharedPreferencesProvider.CATEGORY_TOP)
+                R.id.RadioButtonPopular    -> viewModel.putCategoryProperty(SharedPreferencesProvider.CATEGORY_POPULAR)
+                R.id.RadioButtonUpcoming   -> viewModel.putCategoryProperty(SharedPreferencesProvider.CATEGORY_UPCOMING)
+                R.id.RadioButtonNowPlaying -> viewModel.putCategoryProperty(SharedPreferencesProvider.CATEGORY_PLAYING)
             }
         }
     }

--- a/app/src/main/java/com/sandev/moviesearcher/view/fragments/WatchLaterFragment.kt
+++ b/app/src/main/java/com/sandev/moviesearcher/view/fragments/WatchLaterFragment.kt
@@ -5,10 +5,12 @@ import android.view.Gravity
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.animation.Animation
 import android.view.animation.AnimationUtils
 import android.widget.ImageView
 import androidx.core.view.doOnPreDraw
 import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.lifecycleScope
 import androidx.transition.TransitionInflater
 import com.sandev.moviesearcher.R
 import com.sandev.moviesearcher.data.db.entities.Movie
@@ -17,8 +19,8 @@ import com.sandev.moviesearcher.utils.rv_animators.MovieItemAnimator
 import com.sandev.moviesearcher.view.MainActivity
 import com.sandev.moviesearcher.view.rv_adapters.MoviesRecyclerAdapter
 import com.sandev.moviesearcher.view.viewmodels.WatchLaterFragmentViewModel
-import java.util.concurrent.Executors
-import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 
 
 class WatchLaterFragment : MoviesListFragment() {
@@ -39,9 +41,6 @@ class WatchLaterFragment : MoviesListFragment() {
             viewModel.lastClickedMovie = movie
             mainActivity?.startDetailsFragment(movie, posterView)
         }
-    }
-    private val posterOnClickDummy = object : MoviesRecyclerAdapter.OnClickListener {
-        override fun onClick(movie: Movie, posterView: ImageView) {}
     }
 
 
@@ -94,9 +93,6 @@ class WatchLaterFragment : MoviesListFragment() {
     }
 
     private fun initializeMovieRecyclerList() {
-        // Пока не прошла анимация не обрабатывать клики на постеры
-        viewModel.recyclerAdapter.setPosterOnClickListener(posterOnClickDummy)
-
         binding.moviesListRecycler.apply {
             setHasFixedSize(true)
             isNestedScrollingEnabled = true
@@ -105,8 +101,6 @@ class WatchLaterFragment : MoviesListFragment() {
             itemAnimator = MovieItemAnimator()
 
             doOnPreDraw { startPostponedEnterTransition() }
-
-            viewModel.setActivePosterOnClickListenerAndRemoveMovieIfNeeded(posterOnClick)
         }
     }
 
@@ -117,19 +111,34 @@ class WatchLaterFragment : MoviesListFragment() {
         postponeEnterTransition()  // не запускать анимацию возвращения постера в список пока не просчитается recycler
 
         if (mainActivity?.previousFragmentName == DetailsFragment::class.qualifiedName) {
-            binding.moviesListRecycler.layoutAnimation = AnimationUtils.loadLayoutAnimation(
-                requireContext(),
-                R.anim.posters_appearance
-            )
+            // Пока не прошла анимация не обрабатывать клики на постеры
+            viewModel.blockCallbackOnPosterClick()
 
             resetExitReenterTransitionAnimations()
 
-            Executors.newSingleThreadScheduledExecutor().apply {
-                schedule({ setTransitionAnimation() },
-                    resources.getInteger(R.integer.activity_main_animations_durations_poster_transition).toLong(),
-                    TimeUnit.MILLISECONDS)
-                shutdown()
+            val layoutAnimationListener = object : Animation.AnimationListener {
+                override fun onAnimationStart(animation: Animation?) {}
+                override fun onAnimationRepeat(animation: Animation?) {}
+                override fun onAnimationEnd(animation: Animation) {
+                    viewLifecycleOwner.lifecycleScope.launch {
+                        launch {
+                            binding.moviesListRecycler.layoutAnimationListener = null
+                            setTransitionAnimation(Gravity.END)
+                        }
+                        launch(Dispatchers.Default) {  // Запускать удаление карточки фильма только после отрисовки анимации recycler
+                            viewModel.checkForMovieDeletionNecessary()
+                            viewModel.clickOnPosterCallbackSetupSynchronizeBlock?.receiveCatching()
+                            viewModel.unblockCallbackOnPosterClick(posterOnClick)
+                        }
+                    }
+                }
             }
+            binding.moviesListRecycler.layoutAnimationListener = layoutAnimationListener
+            binding.moviesListRecycler.layoutAnimation = AnimationUtils.loadLayoutAnimation(
+                requireContext(), R.anim.posters_appearance
+            )
+        } else {
+            viewModel.unblockCallbackOnPosterClick(posterOnClick)
         }
     }
 

--- a/app/src/main/java/com/sandev/moviesearcher/view/fragments/WatchLaterFragment.kt
+++ b/app/src/main/java/com/sandev/moviesearcher/view/fragments/WatchLaterFragment.kt
@@ -7,11 +7,10 @@ import android.view.View
 import android.view.ViewGroup
 import android.view.animation.Animation
 import android.view.animation.AnimationUtils
-import android.widget.ImageView
 import androidx.core.view.doOnPreDraw
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
-import androidx.transition.TransitionInflater
+import com.google.android.material.imageview.ShapeableImageView
 import com.sandev.moviesearcher.R
 import com.sandev.moviesearcher.data.db.entities.Movie
 import com.sandev.moviesearcher.databinding.FragmentWatchLaterBinding
@@ -37,7 +36,7 @@ class WatchLaterFragment : MoviesListFragment() {
     private var mainActivity: MainActivity? = null
 
     private val posterOnClick = object : MoviesRecyclerAdapter.OnClickListener {
-        override fun onClick(movie: Movie, posterView: ImageView) {
+        override fun onClick(movie: Movie, posterView: ShapeableImageView) {
             resetExitReenterTransitionAnimations()
             viewModel.lastClickedMovie = movie
             mainActivity?.startDetailsFragment(movie, posterView)
@@ -114,7 +113,6 @@ class WatchLaterFragment : MoviesListFragment() {
     private fun setAllAnimationTransition() {
         setTransitionAnimation()
 
-        sharedElementReturnTransition = TransitionInflater.from(context).inflateTransition(R.transition.poster_transition)
         postponeEnterTransition()  // не запускать анимацию возвращения постера в список пока не просчитается recycler
 
         if (mainActivity?.previousFragmentName == DetailsFragment::class.qualifiedName) {

--- a/app/src/main/java/com/sandev/moviesearcher/view/fragments/WatchLaterFragment.kt
+++ b/app/src/main/java/com/sandev/moviesearcher/view/fragments/WatchLaterFragment.kt
@@ -21,6 +21,7 @@ import com.sandev.moviesearcher.view.rv_adapters.MoviesRecyclerAdapter
 import com.sandev.moviesearcher.view.viewmodels.WatchLaterFragmentViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 
 
 class WatchLaterFragment : MoviesListFragment() {
@@ -52,6 +53,8 @@ class WatchLaterFragment : MoviesListFragment() {
 
         mainActivity = activity as MainActivity
 
+        viewModel.isMovieMoreNotInSavedList = false
+
         val previousFragmentName = mainActivity?.previousFragmentName
         if (previousFragmentName != DetailsFragment::class.qualifiedName) {
             if (previousFragmentName == HomeFragment::class.qualifiedName) {
@@ -80,6 +83,10 @@ class WatchLaterFragment : MoviesListFragment() {
 
     override fun onDestroyView() {
         super.onDestroyView()
+
+        runBlocking {   // Если пользователь быстро нажимал "назад", то это предотвращает неудаление карточки
+            viewModel.checkForMovieDeletionNecessary()
+        }
 
         _binding = null
     }
@@ -120,6 +127,7 @@ class WatchLaterFragment : MoviesListFragment() {
                 override fun onAnimationStart(animation: Animation?) {}
                 override fun onAnimationRepeat(animation: Animation?) {}
                 override fun onAnimationEnd(animation: Animation) {
+                    if (view == null) return
                     viewLifecycleOwner.lifecycleScope.launch {
                         launch {
                             binding.moviesListRecycler.layoutAnimationListener = null

--- a/app/src/main/java/com/sandev/moviesearcher/view/rv_adapters/MoviesRecyclerAdapter.kt
+++ b/app/src/main/java/com/sandev/moviesearcher/view/rv_adapters/MoviesRecyclerAdapter.kt
@@ -43,7 +43,7 @@ class MoviesRecyclerAdapter : RecyclerView.Adapter<MovieViewHolder>() {
         fun onClick(movie: Movie, posterView: ImageView)
     }
 
-    fun setPosterOnClickListener(onClickListener: OnClickListener) {
+    fun setPosterOnClickListener(onClickListener: OnClickListener?) {
         clickListener = onClickListener
     }
 

--- a/app/src/main/java/com/sandev/moviesearcher/view/rv_adapters/MoviesRecyclerAdapter.kt
+++ b/app/src/main/java/com/sandev/moviesearcher/view/rv_adapters/MoviesRecyclerAdapter.kt
@@ -80,11 +80,12 @@ class MoviesRecyclerAdapter : RecyclerView.Adapter<MovieViewHolder>() {
         }
     }
 
-    fun removeMovieCard(movie: Movie) {
+    fun removeMovieCard(movie: Movie): Boolean {
         val index = moviesList.indexOf(movie)
-        if (index == -1) return
+        if (index == -1) return false
         moviesList.removeAt(index)
         notifyItemRemoved(index)
+        return true
     }
 
     fun removeMovieCardAt(position: Int) {

--- a/app/src/main/java/com/sandev/moviesearcher/view/rv_adapters/MoviesRecyclerAdapter.kt
+++ b/app/src/main/java/com/sandev/moviesearcher/view/rv_adapters/MoviesRecyclerAdapter.kt
@@ -2,9 +2,9 @@ package com.sandev.moviesearcher.view.rv_adapters
 
 import android.view.LayoutInflater
 import android.view.ViewGroup
-import android.widget.ImageView
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
+import com.google.android.material.imageview.ShapeableImageView
 import com.sandev.moviesearcher.R
 import com.sandev.moviesearcher.data.db.entities.Movie
 import com.sandev.moviesearcher.databinding.MovieCardBinding
@@ -40,7 +40,7 @@ class MoviesRecyclerAdapter : RecyclerView.Adapter<MovieViewHolder>() {
     }
 
     interface OnClickListener {
-        fun onClick(movie: Movie, posterView: ImageView)
+        fun onClick(movie: Movie, posterView: ShapeableImageView)
     }
 
     fun setPosterOnClickListener(onClickListener: OnClickListener?) {

--- a/app/src/main/java/com/sandev/moviesearcher/view/rv_viewholders/MovieViewHolder.kt
+++ b/app/src/main/java/com/sandev/moviesearcher/view/rv_viewholders/MovieViewHolder.kt
@@ -2,6 +2,7 @@ package com.sandev.moviesearcher.view.rv_viewholders
 
 import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.Glide
+import com.bumptech.glide.request.RequestOptions
 import com.sandev.moviesearcher.R
 import com.sandev.moviesearcher.data.db.entities.Movie
 import com.sandev.moviesearcher.data.themoviedatabase.TmdbApiConstants.IMAGES_URL
@@ -21,6 +22,7 @@ class MovieViewHolder(private val binding: MovieCardBinding) : RecyclerView.View
             Glide.with(binding.root)
                 .load("${IMAGES_URL}${IMAGE_MEDIUM_SIZE}${movieData.poster}")
                 .placeholder(R.drawable.dummy_poster)
+                .apply(RequestOptions().dontTransform())
                 .into(poster)
         } else {
             Glide.with(binding.root)

--- a/app/src/main/java/com/sandev/moviesearcher/view/viewmodels/DetailsFragmentViewModel.kt
+++ b/app/src/main/java/com/sandev/moviesearcher/view/viewmodels/DetailsFragmentViewModel.kt
@@ -10,7 +10,9 @@ import com.sandev.moviesearcher.data.db.entities.Movie
 import com.sandev.moviesearcher.domain.components_holders.FavoritesMoviesComponentHolder
 import com.sandev.moviesearcher.domain.components_holders.WatchLaterMoviesComponentHolder
 import com.sandev.moviesearcher.domain.interactors.TmdbInteractor
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -86,20 +88,36 @@ class DetailsFragmentViewModel : ViewModel() {
         }
     }
 
-    fun addToFavorite(movie: Movie) = viewModelScope.launch {
-        favoritesMoviesComponent.interactor.addToList(movie)
+    fun addToFavorite(movie: Movie) {
+        val oneShotScope = CoroutineScope(Dispatchers.IO)
+        oneShotScope.launch {
+            favoritesMoviesComponent.interactor.addToList(movie)
+            oneShotScope.cancel()
+        }
     }
 
-    fun removeFromFavorite(movie: Movie) = viewModelScope.launch {
-        favoritesMoviesComponent.interactor.removeFromList(movie)
+    fun removeFromFavorite(movie: Movie) {
+        val oneShotScope = CoroutineScope(Dispatchers.IO)
+        oneShotScope.launch {
+            favoritesMoviesComponent.interactor.removeFromList(movie)
+            oneShotScope.cancel()
+        }
     }
 
-    fun addToWatchLater(movie: Movie) = viewModelScope.launch {
-        watchLaterMoviesComponent.interactor.addToList(movie)
+    fun addToWatchLater(movie: Movie) {
+        val oneShotScope = CoroutineScope(Dispatchers.IO)
+        oneShotScope.launch {
+            watchLaterMoviesComponent.interactor.addToList(movie)
+            oneShotScope.cancel()
+        }
     }
 
-    fun removeFromWatchLater(movie: Movie) = viewModelScope.launch {
-        watchLaterMoviesComponent.interactor.removeFromList(movie)
+    fun removeFromWatchLater(movie: Movie) {
+        val oneShotScope = CoroutineScope(Dispatchers.IO)
+        oneShotScope.launch {
+            watchLaterMoviesComponent.interactor.removeFromList(movie)
+            oneShotScope.cancel()
+        }
     }
 
 

--- a/app/src/main/java/com/sandev/moviesearcher/view/viewmodels/DetailsFragmentViewModel.kt
+++ b/app/src/main/java/com/sandev/moviesearcher/view/viewmodels/DetailsFragmentViewModel.kt
@@ -53,12 +53,17 @@ class DetailsFragmentViewModel : ViewModel() {
     suspend fun loadMoviePoster(posterUrl: String): Bitmap {
         return suspendCoroutine { continuation ->
             val url = URL(posterUrl)
-            try {
-                val bitmap = BitmapFactory.decodeStream(url.openConnection().getInputStream())
-                continuation.resume(bitmap)
+
+            val bitmap = try {
+                val connection = url.openConnection()
+                connection.connectTimeout = CONNECTION_TIMEOUT
+                connection.readTimeout = CONNECTION_READ_TIMEOUT
+
+                BitmapFactory.decodeStream(connection.getInputStream())
             } catch(e: Exception) {
                 throw IOException("Connection lost or server didn't respond")
             }
+            continuation.resume(bitmap)
         }
     }
 
@@ -69,4 +74,10 @@ class DetailsFragmentViewModel : ViewModel() {
     fun addToWatchLater(movie: Movie) = watchLaterMoviesComponent.interactor.addToList(movie)
 
     fun removeFromWatchLater(movie: Movie) = watchLaterMoviesComponent.interactor.removeFromList(movie)
+
+
+    companion object {
+        const val CONNECTION_TIMEOUT = 2000
+        const val CONNECTION_READ_TIMEOUT = 2000
+    }
 }

--- a/app/src/main/java/com/sandev/moviesearcher/view/viewmodels/HomeFragmentViewModel.kt
+++ b/app/src/main/java/com/sandev/moviesearcher/view/viewmodels/HomeFragmentViewModel.kt
@@ -61,7 +61,7 @@ class HomeFragmentViewModel : MoviesListFragmentViewModel() {
                 SharedPreferencesProvider.KEY_CATEGORY ->  viewModelScope.launch {
                     currentRepositoryType = provideCurrentMovieListTypeByCategoryInSettings()
 
-                    dispatchQueryToInteractor(query = lastSearch, page = INITIAL_PAGE_IN_RECYCLER)
+                    dispatchQueryToInteractor(page = INITIAL_PAGE_IN_RECYCLER)
                 }
             }
         }
@@ -121,7 +121,7 @@ class HomeFragmentViewModel : MoviesListFragmentViewModel() {
         }
     }
 
-    private fun getSearchedMoviesFromApi(query: CharSequence, page: Int) {
+    private fun getSearchedMoviesFromApi(page: Int) {
         isNeedRefreshLocalDB = false
 
         if (page != nextPage) {
@@ -141,7 +141,7 @@ class HomeFragmentViewModel : MoviesListFragmentViewModel() {
 
             try {
                 interactor.getSearchedMoviesFromApi(
-                    query = query.toString(),
+                    query = lastSearch,
                     page = nextPage
                 ).collect { result ->
                     resultMovies = result.movies
@@ -155,12 +155,12 @@ class HomeFragmentViewModel : MoviesListFragmentViewModel() {
         }
     }
 
-    override fun dispatchQueryToInteractor(query: String?, page: Int?) {
+    override fun dispatchQueryToInteractor(page: Int?) {
         if (isInSearchMode) {
             if (page != null) {
-                getSearchedMoviesFromApi(query = query ?: lastSearch, page = page)
+                getSearchedMoviesFromApi(page = page)
             } else {
-                getSearchedMoviesFromApi(query = query ?: lastSearch, page = nextPage)
+                getSearchedMoviesFromApi(page = nextPage)
             }
         } else {
             if (page != null) {

--- a/app/src/main/java/com/sandev/moviesearcher/view/viewmodels/HomeFragmentViewModel.kt
+++ b/app/src/main/java/com/sandev/moviesearcher/view/viewmodels/HomeFragmentViewModel.kt
@@ -75,6 +75,13 @@ class HomeFragmentViewModel : MoviesListFragmentViewModel() {
     }
 
 
+    fun fullRefreshMoviesList() {
+        isOffline = false
+        isNeedRefreshLocalDB = true
+        lastVisibleMovieCard = 0
+        dispatchQueryToInteractor(page = INITIAL_PAGE_IN_RECYCLER)
+    }
+
     override fun onCleared() {
         sharedPreferencesInteractor.removeSharedPreferencesChangeListener(sharedPreferencesStateListener)
     }

--- a/app/src/main/java/com/sandev/moviesearcher/view/viewmodels/HomeFragmentViewModel.kt
+++ b/app/src/main/java/com/sandev/moviesearcher/view/viewmodels/HomeFragmentViewModel.kt
@@ -3,12 +3,13 @@ package com.sandev.moviesearcher.view.viewmodels
 import android.content.SharedPreferences
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.viewModelScope
 import com.sandev.moviesearcher.App
 import com.sandev.moviesearcher.data.SharedPreferencesProvider
 import com.sandev.moviesearcher.data.db.entities.Movie
 import com.sandev.moviesearcher.domain.interactors.SharedPreferencesInteractor
 import com.sandev.moviesearcher.domain.interactors.TmdbInteractor
-import java.util.concurrent.Executors
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 
@@ -91,7 +92,7 @@ class HomeFragmentViewModel : MoviesListFragmentViewModel() {
 
         if (page > totalPagesInLastQuery) return
 
-        Executors.newSingleThreadExecutor().execute {
+        viewModelScope.launch {
             interactor.getMoviesFromApi(
                 page = nextPage,
                 callback = homeFragmentApiCallback,
@@ -117,7 +118,7 @@ class HomeFragmentViewModel : MoviesListFragmentViewModel() {
 
         if (page > totalPagesInLastQuery) return
 
-        Executors.newSingleThreadExecutor().execute {
+        viewModelScope.launch {
             interactor.getSearchedMoviesFromApi(
                 query = query.toString(),
                 page = nextPage,
@@ -144,7 +145,7 @@ class HomeFragmentViewModel : MoviesListFragmentViewModel() {
 
     private fun loadListFromDB() {
         if (isInSearchMode) {
-            Executors.newSingleThreadExecutor().execute {
+            viewModelScope.launch {
                 moviesList.postValue(interactor.getSearchedMoviesFromDB(
                     query = lastSearch,
                     page = nextPage,
@@ -153,7 +154,7 @@ class HomeFragmentViewModel : MoviesListFragmentViewModel() {
                 ))
             }
         } else {
-            Executors.newSingleThreadExecutor().execute {
+            viewModelScope.launch {
                 moviesList.postValue(interactor.getMoviesFromDB(
                     page = nextPage,
                     moviesPerPage = moviesPerPage,

--- a/app/src/main/java/com/sandev/moviesearcher/view/viewmodels/MoviesListFragmentViewModel.kt
+++ b/app/src/main/java/com/sandev/moviesearcher/view/viewmodels/MoviesListFragmentViewModel.kt
@@ -111,12 +111,6 @@ abstract class MoviesListFragmentViewModel : ViewModel() {
     private fun isNextPageCanBeDownloaded() = nextPage <= totalPagesInLastQuery
 
 
-//    interface ApiCallback {
-//        fun onSuccess(movies: List<Movie>)
-//        fun onFailure()
-//    }
-
-
     companion object {
         const val SEARCH_SYMBOLS_THRESHOLD = 2
 

--- a/app/src/main/java/com/sandev/moviesearcher/view/viewmodels/MoviesListFragmentViewModel.kt
+++ b/app/src/main/java/com/sandev/moviesearcher/view/viewmodels/MoviesListFragmentViewModel.kt
@@ -40,13 +40,6 @@ abstract class MoviesListFragmentViewModel : ViewModel() {
         }
 
 
-    fun fullRefreshMoviesList() {
-        isOffline = false
-        isNeedRefreshLocalDB = true
-        lastVisibleMovieCard = 0
-        dispatchQueryToInteractor(page = INITIAL_PAGE_IN_RECYCLER)
-    }
-
     fun searchInSearchView(query: String) {
         if (query == lastSearch) return
         lastSearch = query

--- a/app/src/main/java/com/sandev/moviesearcher/view/viewmodels/MoviesListFragmentViewModel.kt
+++ b/app/src/main/java/com/sandev/moviesearcher/view/viewmodels/MoviesListFragmentViewModel.kt
@@ -44,26 +44,26 @@ abstract class MoviesListFragmentViewModel : ViewModel() {
         isOffline = false
         isNeedRefreshLocalDB = true
         lastVisibleMovieCard = 0
-        dispatchQueryToInteractor(lastSearch, INITIAL_PAGE_IN_RECYCLER)
+        dispatchQueryToInteractor(page = INITIAL_PAGE_IN_RECYCLER)
     }
 
     fun searchInSearchView(query: String) {
         if (query == lastSearch) return
+        lastSearch = query
 
         if (query.length >= SEARCH_SYMBOLS_THRESHOLD) {
             if (!isInSearchMode) {
                 isInSearchMode = true
                 recyclerAdapter.clearList()
             }
-            dispatchQueryToInteractor(query = query, page = INITIAL_PAGE_IN_RECYCLER)
+            dispatchQueryToInteractor(page = INITIAL_PAGE_IN_RECYCLER)
         } else if (query.isEmpty()) {
             if (isInSearchMode) {
                 isInSearchMode = false
                 recyclerAdapter.clearList()
             }
-            dispatchQueryToInteractor(query = null, page = INITIAL_PAGE_IN_RECYCLER)
+            dispatchQueryToInteractor(page = INITIAL_PAGE_IN_RECYCLER)
         }
-        lastSearch = query
     }
 
     fun startLoadingOnScroll(lastVisibleItemPosition: Int) {
@@ -85,7 +85,7 @@ abstract class MoviesListFragmentViewModel : ViewModel() {
         }
     }
 
-    protected abstract fun dispatchQueryToInteractor(query: String? = null, page: Int? = null)
+    protected abstract fun dispatchQueryToInteractor(page: Int? = null)
 
     private fun initializeRecyclerAdapterList() {
         if (isInSearchMode) {

--- a/app/src/main/java/com/sandev/moviesearcher/view/viewmodels/MoviesListFragmentViewModel.kt
+++ b/app/src/main/java/com/sandev/moviesearcher/view/viewmodels/MoviesListFragmentViewModel.kt
@@ -72,7 +72,7 @@ abstract class MoviesListFragmentViewModel : ViewModel() {
         val relativeThreshold = if (moviesPerPage == 0) {
             nextPage  // Достигнут конец списка, избегается деление на ноль
         } else {
-            ((lastVisibleItemPosition + 1 / moviesPerPage.toFloat()) + PAGINATION_RATIO).roundToInt()
+            ((lastVisibleItemPosition + 1) / moviesPerPage.toFloat() + PAGINATION_RATIO).roundToInt()
         }
         val isItTimeToLoadNextPage = relativeThreshold > nextPage
 
@@ -111,10 +111,10 @@ abstract class MoviesListFragmentViewModel : ViewModel() {
     private fun isNextPageCanBeDownloaded() = nextPage <= totalPagesInLastQuery
 
 
-    interface ApiCallback {
-        fun onSuccess(movies: List<Movie>, totalPages: Int)
-        fun onFailure()
-    }
+//    interface ApiCallback {
+//        fun onSuccess(movies: List<Movie>)
+//        fun onFailure()
+//    }
 
 
     companion object {

--- a/app/src/main/java/com/sandev/moviesearcher/view/viewmodels/SavedMoviesListViewModel.kt
+++ b/app/src/main/java/com/sandev/moviesearcher/view/viewmodels/SavedMoviesListViewModel.kt
@@ -36,6 +36,7 @@ abstract class SavedMoviesListViewModel : MoviesListFragmentViewModel() {
             val isMovieDeleted = recyclerAdapter.removeMovieCard(deletedMovie)
             if (isMovieDeleted && moviesPaginationOffset > 0) {
                 --moviesPaginationOffset
+                nextPage = INITIAL_PAGE_IN_RECYCLER
             }
             unblockCallbackOnPosterClick()
         }
@@ -43,6 +44,9 @@ abstract class SavedMoviesListViewModel : MoviesListFragmentViewModel() {
             if (recyclerAdapter.itemCount == 0) {
                 dispatchQueryToInteractor(page = INITIAL_PAGE_IN_RECYCLER)
             } else {
+                // Сохранённые списки не зависят от nextPage напрямую, только от moviesPaginationOffset,
+                // поэтому сбрасываем страницу при каждом обновлении чтобы пагинация загружала новые страницы
+                nextPage = INITIAL_PAGE_IN_RECYCLER
                 if (moviesPerPage == 0) {  // Пагинация в последний раз дошла до конца списка
                     softResetPagination()
                 }

--- a/app/src/main/java/com/sandev/moviesearcher/view/viewmodels/SavedMoviesListViewModel.kt
+++ b/app/src/main/java/com/sandev/moviesearcher/view/viewmodels/SavedMoviesListViewModel.kt
@@ -43,7 +43,7 @@ abstract class SavedMoviesListViewModel : MoviesListFragmentViewModel() {
             if (recyclerAdapter.itemCount == 0) {
                 dispatchQueryToInteractor(page = INITIAL_PAGE_IN_RECYCLER)
             } else {
-                softResetPagination(moviesPerPage = 1)
+                softResetPagination()
             }
         }
 
@@ -70,14 +70,14 @@ abstract class SavedMoviesListViewModel : MoviesListFragmentViewModel() {
         savedMoviesComponent.interactor.getMovieAddedNotify.removeObserver(movieAddedObserver)
     }
 
-    override fun dispatchQueryToInteractor(query: String?, page: Int?) {
+    override fun dispatchQueryToInteractor(page: Int?) {
         if (page == INITIAL_PAGE_IN_RECYCLER) {
             hardResetPagination()
         }
 
         if (isInSearchMode) {
-            getSearchedMoviesFromApi(
-                query = query ?: lastSearch,
+            getSearchedMoviesFromDB(
+                query = lastSearch,
                 offset = moviesPaginationOffset,
                 moviesCount = moviesPerPage
             )
@@ -113,7 +113,7 @@ abstract class SavedMoviesListViewModel : MoviesListFragmentViewModel() {
         )
     }
 
-    private fun getSearchedMoviesFromApi(query: String, offset: Int, moviesCount: Int) = viewModelScope.launch {
+    private fun getSearchedMoviesFromDB(query: String, offset: Int, moviesCount: Int) = viewModelScope.launch {
         moviesList.postValue(
             savedMoviesComponent.interactor.getFewSearchedMoviesFromList(
                 query = query,
@@ -142,9 +142,14 @@ abstract class SavedMoviesListViewModel : MoviesListFragmentViewModel() {
         moviesPaginationOffset = 0
     }
 
-    private fun softResetPagination(moviesPerPage: Int = MoviesListInteractor.MOVIES_PER_PAGE) {
+    private fun softResetPagination() {
         nextPage = INITIAL_PAGE_IN_RECYCLER
-        this.moviesPerPage = moviesPerPage
+        moviesPerPage = SOFT_RESET_PAGINATION_MOVIES_PER_PAGE
         lastVisibleMovieCard = 0
+    }
+
+
+    companion object {
+        const val SOFT_RESET_PAGINATION_MOVIES_PER_PAGE = 1
     }
 }

--- a/app/src/main/java/com/sandev/moviesearcher/view/viewmodels/SettingsFragmentViewModel.kt
+++ b/app/src/main/java/com/sandev/moviesearcher/view/viewmodels/SettingsFragmentViewModel.kt
@@ -1,17 +1,16 @@
 package com.sandev.moviesearcher.view.viewmodels
 
-import android.content.Context
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
 import com.sandev.moviesearcher.App
-import com.sandev.moviesearcher.R
 import com.sandev.moviesearcher.domain.interactors.SharedPreferencesInteractor
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 
-class SettingsFragmentViewModel(context: Context) : ViewModel() {
+class SettingsFragmentViewModel() : ViewModel() {
 
     @Inject
     lateinit var sharedPreferencesInteractor: SharedPreferencesInteractor
@@ -19,10 +18,6 @@ class SettingsFragmentViewModel(context: Context) : ViewModel() {
     private val categoryProperty: MutableLiveData<String> = MutableLiveData()
     val getCategoryProperty: LiveData<String> = categoryProperty
 
-    val categoryPopular = context.getString(R.string.shared_preferences_settings_value_category_popular)
-    val categoryTopRated = context.getString(R.string.shared_preferences_settings_value_category_top_rated)
-    val categoryUpcoming = context.getString(R.string.shared_preferences_settings_value_category_upcoming)
-    val categoryNowPlaying = context.getString(R.string.shared_preferences_settings_value_category_now_playing)
 
     init {
         App.instance.getAppComponent().inject(this)
@@ -30,26 +25,12 @@ class SettingsFragmentViewModel(context: Context) : ViewModel() {
     }
 
 
-    private fun getCategoryProperty() {
-        categoryProperty.value = sharedPreferencesInteractor.getDefaultMoviesCategoryInMainList()
+    private fun getCategoryProperty() = viewModelScope.launch {
+        categoryProperty.postValue(sharedPreferencesInteractor.getDefaultMoviesCategoryInMainList())
     }
 
-    fun putCategoryProperty(category: String) {
+    fun putCategoryProperty(category: String) = viewModelScope.launch {
         sharedPreferencesInteractor.setDefaultMoviesCategoryInMainList(category)
         getCategoryProperty()
-    }
-
-
-    class MyViewModelFactory(private val context: Context) : ViewModelProvider.Factory {
-
-        @Suppress("UNCHECKED_CAST")
-        override fun <T : ViewModel> create(modelClass: Class<T>): T {
-
-            if (modelClass.isAssignableFrom(SettingsFragmentViewModel::class.java)) {
-                return SettingsFragmentViewModel(context) as T
-            }
-
-            throw IllegalArgumentException("Unknown ViewModel class")
-        }
     }
 }

--- a/app/src/main/res/layout-land/fragment_favorites.xml
+++ b/app/src/main/res/layout-land/fragment_favorites.xml
@@ -26,7 +26,8 @@
         android:id="@+id/app_bar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="?attr/colorPrimaryContainer">
+        android:background="?attr/colorPrimaryContainer"
+        app:elevation="0dp">
 
         <com.google.android.material.search.SearchBar
             android:id="@+id/search_bar"

--- a/app/src/main/res/layout-land/fragment_watch_later.xml
+++ b/app/src/main/res/layout-land/fragment_watch_later.xml
@@ -26,7 +26,8 @@
         android:id="@+id/app_bar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="?attr/colorPrimaryContainer">
+        android:background="?attr/colorPrimaryContainer"
+        app:elevation="0dp">
 
         <com.google.android.material.search.SearchBar
             android:id="@+id/search_bar"

--- a/app/src/main/res/layout-land/merge_fragment_home_content.xml
+++ b/app/src/main/res/layout-land/merge_fragment_home_content.xml
@@ -33,7 +33,8 @@
         android:id="@+id/app_bar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="?attr/colorPrimaryContainer">
+        android:background="?attr/colorPrimaryContainer"
+        app:elevation="0dp">
 
         <com.google.android.material.search.SearchBar
             android:id="@+id/search_bar"

--- a/app/src/main/res/layout/fragment_favorites.xml
+++ b/app/src/main/res/layout/fragment_favorites.xml
@@ -22,7 +22,8 @@
         android:id="@+id/app_bar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="?attr/colorPrimaryContainer">
+        android:background="?attr/colorPrimaryContainer"
+        app:elevation="0dp">
 
         <com.google.android.material.search.SearchBar
             android:id="@+id/search_bar"

--- a/app/src/main/res/layout/fragment_watch_later.xml
+++ b/app/src/main/res/layout/fragment_watch_later.xml
@@ -22,7 +22,8 @@
         android:id="@+id/app_bar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="?attr/colorPrimaryContainer">
+        android:background="?attr/colorPrimaryContainer"
+        app:elevation="0dp">
 
         <com.google.android.material.search.SearchBar
             android:id="@+id/search_bar"

--- a/app/src/main/res/layout/merge_fragment_home_content.xml
+++ b/app/src/main/res/layout/merge_fragment_home_content.xml
@@ -31,7 +31,8 @@
         android:id="@+id/app_bar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="?attr/colorPrimaryContainer">
+        android:background="?attr/colorPrimaryContainer"
+        app:elevation="0dp">
 
         <com.google.android.material.search.SearchBar
             android:id="@+id/search_bar"


### PR DESCRIPTION
#### Многопоточность переведена на корутины заместо создания потоков через пулы;
- Во всех интеракторах методы, которые отвечают за чтение/изменение данных, стали suspend методами.
Среди таких интеракторов [MoviesListInteractor](https://github.com/Sanektys/MovieSearcher/blob/module_43/app/src/main/java/com/sandev/moviesearcher/domain/interactors/MoviesListInteractor.kt), [TmdbInteractor](https://github.com/Sanektys/MovieSearcher/blob/module_43/app/src/main/java/com/sandev/moviesearcher/domain/interactors/TmdbInteractor.kt), [SharedPreferencesInteractor](https://github.com/Sanektys/MovieSearcher/blob/module_43/app/src/main/java/com/sandev/moviesearcher/domain/interactors/SharedPreferencesInteractor.kt);
- В процессе получения данных через Retrofit теперь не используются коллбэки, их заменил Flow. В методах [интерактора](https://github.com/Sanektys/MovieSearcher/blob/module_43/app/src/main/java/com/sandev/moviesearcher/domain/interactors/TmdbInteractor.kt), ответственного за получение данных из сети, [запрос фильмов по категории](https://github.com/Sanektys/MovieSearcher/blob/module_43/app/src/main/java/com/sandev/moviesearcher/domain/interactors/TmdbInteractor.kt#L49) или [запрос фильмов по названию](https://github.com/Sanektys/MovieSearcher/blob/module_43/app/src/main/java/com/sandev/moviesearcher/domain/interactors/TmdbInteractor.kt#L66) создаёт объект Flow, который обрабатывается в соответствующих методах ViewModel (в [этом](https://github.com/Sanektys/MovieSearcher/blob/module_43/app/src/main/java/com/sandev/moviesearcher/view/viewmodels/HomeFragmentViewModel.kt#L107) и [этом](https://github.com/Sanektys/MovieSearcher/blob/module_43/app/src/main/java/com/sandev/moviesearcher/view/viewmodels/HomeFragmentViewModel.kt#L150));

Другие изменения:
- Анимации, которые запускаются после других анимаций в некоторых экранах, теперь запускаются по коллбэку окончания предыдущей анимации, а не по таймеру. В случае непредвиденных зависаний это позволяет сохранить последовательность этих анимаций;
- Исправлены глитчи изображения постера при переходе на экран деталей;
- Исправлены различные ошибки с неудачными удалениями или добавлениями карточек фильмов в сохранённый список из других экранов, не относящихся к этому списку;
- Исправлена некорректная пагинация в сохранённых списках (Избранное/Смотреть позже);
- Теперь поисковый запрос остаётся на экране после выхода из поля поиска и восстанавливается после финиша активити (и, следовательно, приложения) с последующим перезапуском (только если приложение не было выгружено полностью).