### PR TITLE
Some coroutines has been replaced to RXJava

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -61,6 +61,7 @@ dependencies {
     def retrofitGsonVersion = "2.9.0"
     implementation "com.squareup.retrofit2:retrofit:$retrofitVersion"
     implementation "com.squareup.retrofit2:converter-gson:$retrofitGsonVersion"
+    implementation "com.squareup.retrofit2:adapter-rxjava3:$retrofitVersion"
 
     // OkHttp
     def okHttpLoggingVersion = "4.11.0"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -48,6 +48,7 @@ dependencies {
     // Room
     def roomVersion = "2.5.2"
     implementation "androidx.room:room-runtime:$roomVersion"
+    implementation "androidx.room:room-rxjava3:$roomVersion"
     kapt "androidx.room:room-compiler:$roomVersion"
 
     // Dagger

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -74,6 +74,12 @@ dependencies {
     def lottieVersion = "6.0.0"
     implementation "com.airbnb.android:lottie:$lottieVersion"
 
+    // RXJava
+    def rxJavaVersion = "3.1.5"
+    def rxJavaVersionForAndroid = "3.0.2"
+    implementation "io.reactivex.rxjava3:rxandroid:$rxJavaVersionForAndroid"
+    implementation "io.reactivex.rxjava3:rxjava:$rxJavaVersion"
+
     implementation 'androidx.core:core-ktx:1.10.1'
     implementation 'androidx.appcompat:appcompat:1.6.1'
     implementation 'com.google.android.material:material:1.9.0'

--- a/app/src/main/java/com/sandev/moviesearcher/data/db/dao/FavoriteMovieDao.kt
+++ b/app/src/main/java/com/sandev/moviesearcher/data/db/dao/FavoriteMovieDao.kt
@@ -7,13 +7,14 @@ import androidx.room.Query
 import com.sandev.moviesearcher.data.db.entities.FavoriteMovie
 import com.sandev.moviesearcher.data.db.entities.Movie
 import com.sandev.moviesearcher.data.db.entities.TitleAndDescription
+import io.reactivex.rxjava3.core.Observable
 
 
 @Dao
 interface FavoriteMovieDao : SavedMovieDao {
 
     @Query("SELECT * FROM ${FavoriteMovie.TABLE_NAME}")
-    override fun getAllCachedMovies(): LiveData<List<Movie>>
+    override fun getAllCachedMovies(): Observable<List<Movie>>
 
     @Query("SELECT *" +
             "FROM " +

--- a/app/src/main/java/com/sandev/moviesearcher/data/db/dao/MovieDao.kt
+++ b/app/src/main/java/com/sandev/moviesearcher/data/db/dao/MovieDao.kt
@@ -2,11 +2,12 @@ package com.sandev.moviesearcher.data.db.dao
 
 import androidx.lifecycle.LiveData
 import com.sandev.moviesearcher.data.db.entities.Movie
+import io.reactivex.rxjava3.core.Observable
 
 
 interface MovieDao {
 
-    fun getAllCachedMovies(): LiveData<List<Movie>>
+    fun getAllCachedMovies(): Observable<List<Movie>>
 
     fun getLastFewCachedMovies(moviesCount: Int): LiveData<List<Movie>>
 

--- a/app/src/main/java/com/sandev/moviesearcher/data/db/dao/PlayingMovieDao.kt
+++ b/app/src/main/java/com/sandev/moviesearcher/data/db/dao/PlayingMovieDao.kt
@@ -8,13 +8,14 @@ import androidx.room.Query
 import androidx.room.Transaction
 import com.sandev.moviesearcher.data.db.entities.Movie
 import com.sandev.moviesearcher.data.db.entities.PlayingMovie
+import io.reactivex.rxjava3.core.Observable
 
 
 @Dao
 abstract class PlayingMovieDao : MovieDao {
 
     @Query("SELECT * FROM ${PlayingMovie.TABLE_NAME}")
-    abstract override fun getAllCachedMovies(): LiveData<List<Movie>>
+    abstract override fun getAllCachedMovies(): Observable<List<Movie>>
 
     @Query("SELECT *" +
             "FROM " +

--- a/app/src/main/java/com/sandev/moviesearcher/data/db/dao/PopularMovieDao.kt
+++ b/app/src/main/java/com/sandev/moviesearcher/data/db/dao/PopularMovieDao.kt
@@ -8,13 +8,14 @@ import androidx.room.Query
 import androidx.room.Transaction
 import com.sandev.moviesearcher.data.db.entities.Movie
 import com.sandev.moviesearcher.data.db.entities.PopularMovie
+import io.reactivex.rxjava3.core.Observable
 
 
 @Dao
 abstract class PopularMovieDao : MovieDao {
 
     @Query("SELECT * FROM ${PopularMovie.TABLE_NAME}")
-    abstract override fun getAllCachedMovies(): LiveData<List<Movie>>
+    abstract override fun getAllCachedMovies(): Observable<List<Movie>>
 
     @Query("SELECT *" +
             "FROM " +

--- a/app/src/main/java/com/sandev/moviesearcher/data/db/dao/TopMovieDao.kt
+++ b/app/src/main/java/com/sandev/moviesearcher/data/db/dao/TopMovieDao.kt
@@ -8,13 +8,14 @@ import androidx.room.Query
 import androidx.room.Transaction
 import com.sandev.moviesearcher.data.db.entities.Movie
 import com.sandev.moviesearcher.data.db.entities.TopMovie
+import io.reactivex.rxjava3.core.Observable
 
 
 @Dao
 abstract class TopMovieDao : MovieDao {
 
     @Query("SELECT * FROM ${TopMovie.TABLE_NAME}")
-    abstract override fun getAllCachedMovies(): LiveData<List<Movie>>
+    abstract override fun getAllCachedMovies(): Observable<List<Movie>>
 
     @Query("SELECT *" +
             "FROM " +

--- a/app/src/main/java/com/sandev/moviesearcher/data/db/dao/UpcomingMovieDao.kt
+++ b/app/src/main/java/com/sandev/moviesearcher/data/db/dao/UpcomingMovieDao.kt
@@ -8,13 +8,14 @@ import androidx.room.Query
 import androidx.room.Transaction
 import com.sandev.moviesearcher.data.db.entities.Movie
 import com.sandev.moviesearcher.data.db.entities.UpcomingMovie
+import io.reactivex.rxjava3.core.Observable
 
 
 @Dao
 abstract class UpcomingMovieDao : MovieDao {
 
     @Query("SELECT * FROM ${UpcomingMovie.TABLE_NAME}")
-    abstract override fun getAllCachedMovies(): LiveData<List<Movie>>
+    abstract override fun getAllCachedMovies(): Observable<List<Movie>>
 
     @Query("SELECT *" +
             "FROM " +

--- a/app/src/main/java/com/sandev/moviesearcher/data/db/dao/WatchLaterMovieDao.kt
+++ b/app/src/main/java/com/sandev/moviesearcher/data/db/dao/WatchLaterMovieDao.kt
@@ -7,13 +7,14 @@ import androidx.room.Query
 import com.sandev.moviesearcher.data.db.entities.Movie
 import com.sandev.moviesearcher.data.db.entities.TitleAndDescription
 import com.sandev.moviesearcher.data.db.entities.WatchLaterMovie
+import io.reactivex.rxjava3.core.Observable
 
 
 @Dao
 interface WatchLaterMovieDao : SavedMovieDao {
 
     @Query("SELECT * FROM ${WatchLaterMovie.TABLE_NAME}")
-    override fun getAllCachedMovies(): LiveData<List<Movie>>
+    override fun getAllCachedMovies(): Observable<List<Movie>>
 
     @Query("SELECT *" +
             "FROM " +

--- a/app/src/main/java/com/sandev/moviesearcher/data/repositories/MoviesListRepository.kt
+++ b/app/src/main/java/com/sandev/moviesearcher/data/repositories/MoviesListRepository.kt
@@ -2,13 +2,14 @@ package com.sandev.moviesearcher.data.repositories
 
 import androidx.lifecycle.LiveData
 import com.sandev.moviesearcher.data.db.entities.Movie
+import io.reactivex.rxjava3.core.Observable
 
 
 interface MoviesListRepository {
 
     fun putToDB(movies: List<Movie>)
 
-    fun getAllFromDB(): LiveData<List<Movie>>
+    fun getAllFromDB(): Observable<List<Movie>>
 
     fun getFromDB(moviesCount: Int): LiveData<List<Movie>>
 

--- a/app/src/main/java/com/sandev/moviesearcher/data/repositories/MoviesListRepositoryImpl.kt
+++ b/app/src/main/java/com/sandev/moviesearcher/data/repositories/MoviesListRepositoryImpl.kt
@@ -13,6 +13,7 @@ import com.sandev.moviesearcher.data.db.entities.PlayingMovie
 import com.sandev.moviesearcher.data.db.entities.PopularMovie
 import com.sandev.moviesearcher.data.db.entities.TopMovie
 import com.sandev.moviesearcher.data.db.entities.UpcomingMovie
+import io.reactivex.rxjava3.core.Observable
 
 
 open class MoviesListRepositoryImpl(private val movieDao: MovieDao) : MoviesListRepository {
@@ -35,7 +36,7 @@ open class MoviesListRepositoryImpl(private val movieDao: MovieDao) : MoviesList
         }
     }
 
-    override fun getAllFromDB(): LiveData<List<Movie>>
+    override fun getAllFromDB(): Observable<List<Movie>>
             = movieDao.getAllCachedMovies()
 
     override fun getFromDB(moviesCount: Int): LiveData<List<Movie>>

--- a/app/src/main/java/com/sandev/moviesearcher/data/themoviedatabase/TmdbApi.kt
+++ b/app/src/main/java/com/sandev/moviesearcher/data/themoviedatabase/TmdbApi.kt
@@ -1,5 +1,6 @@
 package com.sandev.moviesearcher.data.themoviedatabase
 
+import io.reactivex.rxjava3.core.Single
 import retrofit2.http.GET
 import retrofit2.http.Path
 import retrofit2.http.Query
@@ -7,18 +8,18 @@ import retrofit2.http.Query
 
 interface TmdbApi {
     @GET("movie/{category}")
-    suspend fun getMovies(
+    fun getMovies(
         @Path("category") category: String,
         @Query("api_key") apiKey: String,
         @Query("language") language: String,
         @Query("page") page: Int
-    ): TmdbResultDto
+    ): Single<TmdbResultDto>
 
     @GET("search/movie")
-    suspend fun getSearchedMovies(
+    fun getSearchedMovies(
         @Query("api_key") apiKey: String,
         @Query("query") query: String,
         @Query("language") language: String,
         @Query("page") page: Int
-    ): TmdbResultDto
+    ): Single<TmdbResultDto>
 }

--- a/app/src/main/java/com/sandev/moviesearcher/domain/RetrofitBuilder.kt
+++ b/app/src/main/java/com/sandev/moviesearcher/domain/RetrofitBuilder.kt
@@ -3,6 +3,7 @@ package com.sandev.moviesearcher.domain
 import com.sandev.moviesearcher.data.themoviedatabase.TmdbApiConstants
 import okhttp3.OkHttpClient
 import retrofit2.Retrofit
+import retrofit2.adapter.rxjava3.RxJava3CallAdapterFactory
 import retrofit2.converter.gson.GsonConverterFactory
 
 
@@ -10,6 +11,7 @@ object RetrofitBuilder {
     fun build(client: OkHttpClient) = Retrofit.Builder()
         .baseUrl(TmdbApiConstants.BASE_URL)
         .addConverterFactory(GsonConverterFactory.create())
+        .addCallAdapterFactory(RxJava3CallAdapterFactory.createSynchronous())
         .client(client)
         .build()
 }

--- a/app/src/main/java/com/sandev/moviesearcher/view/viewmodels/DetailsFragmentViewModel.kt
+++ b/app/src/main/java/com/sandev/moviesearcher/view/viewmodels/DetailsFragmentViewModel.kt
@@ -19,8 +19,6 @@ import kotlinx.coroutines.withContext
 import java.io.IOException
 import java.net.URL
 import javax.inject.Inject
-import kotlin.coroutines.resume
-import kotlin.coroutines.suspendCoroutine
 
 
 class DetailsFragmentViewModel : ViewModel() {
@@ -71,21 +69,19 @@ class DetailsFragmentViewModel : ViewModel() {
     }
 
 
-    suspend fun loadMoviePoster(posterUrl: String): Bitmap {
-        return suspendCoroutine { continuation ->
-            val url = URL(posterUrl)
+    fun loadMoviePoster(posterUrl: String): Bitmap {
+        val url = URL(posterUrl)
 
-            val bitmap = try {
-                val connection = url.openConnection()
-                connection.connectTimeout = CONNECTION_TIMEOUT
-                connection.readTimeout = CONNECTION_READ_TIMEOUT
+        val bitmap = try {
+            val connection = url.openConnection()
+            connection.connectTimeout = CONNECTION_TIMEOUT
+            connection.readTimeout = CONNECTION_READ_TIMEOUT
 
-                BitmapFactory.decodeStream(connection.getInputStream())
-            } catch(e: Exception) {
-                throw IOException("Connection lost or server didn't respond")
-            }
-            continuation.resume(bitmap)
+            BitmapFactory.decodeStream(connection.getInputStream())
+        } catch(e: Exception) {
+            throw IOException("Connection lost or server didn't respond")
         }
+        return bitmap
     }
 
     fun addToFavorite(movie: Movie) {

--- a/app/src/main/java/com/sandev/moviesearcher/view/viewmodels/FavoritesFragmentViewModel.kt
+++ b/app/src/main/java/com/sandev/moviesearcher/view/viewmodels/FavoritesFragmentViewModel.kt
@@ -23,10 +23,10 @@ class FavoritesFragmentViewModel : SavedMoviesListViewModel() {
 
         savedMoviesComponent = favoritesMoviesComponent
 
+        dispatchQueryToInteractor(page = INITIAL_PAGE_IN_RECYCLER)
+
         favoritesMoviesComponent.interactor.getDeletedMovie.observeForever(movieDeletedObserver)
         favoritesMoviesComponent.interactor.getMovieAddedNotify.observeForever(movieAddedObserver)
-
-        dispatchQueryToInteractor(page = INITIAL_PAGE_IN_RECYCLER)
     }
 
 

--- a/app/src/main/java/com/sandev/moviesearcher/view/viewmodels/WatchLaterFragmentViewModel.kt
+++ b/app/src/main/java/com/sandev/moviesearcher/view/viewmodels/WatchLaterFragmentViewModel.kt
@@ -25,10 +25,10 @@ class WatchLaterFragmentViewModel : SavedMoviesListViewModel() {
 
         savedMoviesComponent = watchLaterMoviesComponent
 
+        dispatchQueryToInteractor(page = INITIAL_PAGE_IN_RECYCLER)
+
         watchLaterMoviesComponent.interactor.getDeletedMovie.observeForever(movieDeletedObserver)
         watchLaterMoviesComponent.interactor.getMovieAddedNotify.observeForever(movieAddedObserver)
-
-        dispatchQueryToInteractor(page = INITIAL_PAGE_IN_RECYCLER)
     }
 
 


### PR DESCRIPTION
#### Некоторая часть корутин, отвечающая за получение данных из БД и API, а также за загрузку в БД, была заменена библиотекой RxJava:
- В DAO интерфейсах, [метод](https://github.com/Sanektys/MovieSearcher/blob/module_44/app/src/main/java/com/sandev/moviesearcher/data/db/dao/FavoriteMovieDao.kt#L17), возвращающий раньше LiveData, стал возвращать Observable. Это позволило легко получать данные о наличии определённого фильма в списке избранного/смотреть_позже [на экране деталей](https://github.com/Sanektys/MovieSearcher/blob/module_44/app/src/main/java/com/sandev/moviesearcher/view/fragments/DetailsFragment.kt#L191);
- Все методы в [интеракторе](https://github.com/Sanektys/MovieSearcher/blob/module_44/app/src/main/java/com/sandev/moviesearcher/domain/interactors/MoviesListInteractor.kt) сохранённых списков фильмов оперируют или Single, или Completable потоками при работе с БД;
- То же касается и [интерактора API запросов](https://github.com/Sanektys/MovieSearcher/blob/module_44/app/src/main/java/com/sandev/moviesearcher/domain/interactors/TmdbInteractor.kt) на сервер, но вдобавок к этому есть два метода, что обрабатывают приходящий с [интерфейса запросов](https://github.com/Sanektys/MovieSearcher/blob/module_44/app/src/main/java/com/sandev/moviesearcher/data/themoviedatabase/TmdbApi.kt) объект [Single](https://github.com/Sanektys/MovieSearcher/blob/module_44/app/src/main/java/com/sandev/moviesearcher/data/themoviedatabase/TmdbApi.kt#L16) и [преобразуют](https://github.com/Sanektys/MovieSearcher/blob/module_44/app/src/main/java/com/sandev/moviesearcher/domain/interactors/TmdbInteractor.kt#L54) приходящий с него DTO объект в конечный вариант представления данных.